### PR TITLE
Export of internal changes

### DIFF
--- a/common/escaping.cc
+++ b/common/escaping.cc
@@ -266,7 +266,7 @@ absl::optional<std::string> unescape(const std::string& s, bool is_bytes) {
   // Raw string preceded by the 'r|R' prefix.
   bool is_raw_literal = false;
   if (value[0] == 'r' || value[0] == 'R') {
-    value.resize(value.size() - 1);
+    value = value.substr(1, n - 1);
     n = value.size();
     is_raw_literal = true;
   }

--- a/common/escaping_test.cc
+++ b/common/escaping_test.cc
@@ -35,6 +35,7 @@ std::vector<TestInfo> test_cases = {
     {R"("\\")", "\\"},
     {"'''x''x'''", "x''x"},
     {R"("""x""x""")", R"(x""x)"},
+    {R"(r"")", ""},
     // Octal 303 -> Code point 195 (Ã)
     // Octal 277 -> Code point 191 (¿)
     {R"("\303\277")", "Ã¿"},

--- a/conformance/BUILD
+++ b/conformance/BUILD
@@ -38,11 +38,13 @@ cc_binary(
         "//eval/eval:container_backed_map_impl",
         "//eval/public:builtin_func_registrar",
         "//eval/public:cel_expr_builder_factory",
+        "//parser",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/strings",
         "@com_google_googleapis//google/api/expr/v1alpha1:checked_cc_proto",
         "@com_google_googleapis//google/api/expr/v1alpha1:conformance_service_cc_grpc",
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
+        "@com_google_googleapis//google/rpc:code_cc_proto",
         "@com_google_protobuf//:protobuf",
     ],
 )
@@ -53,8 +55,8 @@ cc_binary(
         srcs = [":" + driver],
         args = [
             "$(location @com_google_cel_spec//tests/simple:simple_test)",
-            "--server=$(location @com_google_cel_go//server/main:cel_server)",
-            "--eval_server=$(location :server)",
+            "--server=$(location :server)",
+            "--check_server=$(location @com_google_cel_go//server/main:cel_server)",
             # Requires container support
             "--skip_test=basic/namespace/self_eval_container_lookup,self_eval_container_lookup_unchecked",
             # Requires heteregenous equality spec clarification
@@ -83,8 +85,8 @@ sh_test(
     srcs = ["@com_google_cel_spec//tests:conftest-nofail.sh"],
     args = [
         "$(location @com_google_cel_spec//tests/simple:simple_test)",
-        "--server=$(location @com_google_cel_go//server/main:cel_server)",
-        "--eval_server=$(location :server)",
+        "--server=$(location :server)",
+        "--check_server=$(location @com_google_cel_go//server/main:cel_server)",
     ] + ["$(location " + test + ")" for test in DASHBOARD_TESTS],
     data = [
         ":server",

--- a/eval/eval/evaluator_core.cc
+++ b/eval/eval/evaluator_core.cc
@@ -18,12 +18,12 @@ const ExpressionStep* ExecutionFrame::Next() {
 }
 
 cel_base::StatusOr<CelValue> CelExpressionFlatImpl::Evaluate(
-    const Activation& activation, google::protobuf::Arena* arena) const {
+    const BaseActivation& activation, google::protobuf::Arena* arena) const {
   return Trace(activation, arena, CelEvaluationListener());
 }
 
 cel_base::StatusOr<CelValue> CelExpressionFlatImpl::Trace(
-    const Activation& activation, google::protobuf::Arena* arena,
+    const BaseActivation& activation, google::protobuf::Arena* arena,
     CelEvaluationListener callback) const {
   ExecutionFrame frame(&path_, activation, arena, max_iterations_);
 

--- a/eval/eval/evaluator_core.h
+++ b/eval/eval/evaluator_core.h
@@ -95,7 +95,7 @@ class ExecutionFrame {
   // flat is the flattened sequence of execution steps that will be evaluated.
   // activation provides bindings between parameter names and values.
   // arena serves as allocation manager during the expression evaluation.
-  ExecutionFrame(const ExecutionPath* flat, const Activation& activation,
+  ExecutionFrame(const ExecutionPath* flat, const BaseActivation& activation,
                  google::protobuf::Arena* arena, int max_iterations)
       : pc_(0UL),
         execution_path_(flat),
@@ -129,7 +129,7 @@ class ExecutionFrame {
   google::protobuf::Arena* arena() { return arena_; }
 
   // Returns reference to Activation
-  const Activation& activation() const { return activation_; }
+  const BaseActivation& activation() const { return activation_; }
 
   // Returns reference to iter_vars
   std::map<std::string, CelValue>& iter_vars() { return iter_vars_; }
@@ -151,7 +151,7 @@ class ExecutionFrame {
  private:
   size_t pc_;  // pc_ - Program Counter. Current position on execution path.
   const ExecutionPath* execution_path_;
-  const Activation& activation_;
+  const BaseActivation& activation_;
   ValueStack value_stack_;
   google::protobuf::Arena* arena_;
   const int max_iterations_;
@@ -173,11 +173,11 @@ class CelExpressionFlatImpl : public CelExpression {
       : path_(std::move(path)), max_iterations_(max_iterations) {}
 
   // Implementation of CelExpression evaluate method.
-  cel_base::StatusOr<CelValue> Evaluate(const Activation& activation,
+  cel_base::StatusOr<CelValue> Evaluate(const BaseActivation& activation,
                                     google::protobuf::Arena* arena) const override;
 
   // Implementation of CelExpression trace method.
-  cel_base::StatusOr<CelValue> Trace(const Activation& activation,
+  cel_base::StatusOr<CelValue> Trace(const BaseActivation& activation,
                                  google::protobuf::Arena* arena,
                                  CelEvaluationListener callback) const override;
 

--- a/eval/eval/function_step.cc
+++ b/eval/eval/function_step.cc
@@ -149,7 +149,7 @@ cel_base::StatusOr<const CelFunction*> LazyFunctionStep::ResolveFunction(
 
   CelFunctionDescriptor matcher{name_, receiver_style_, arg_types};
 
-  const Activation& activation = frame->activation();
+  const BaseActivation& activation = frame->activation();
   for (auto provider : providers_) {
     auto status = provider->GetFunction(matcher, activation);
     if (!status.ok()) {

--- a/eval/public/cel_expression.h
+++ b/eval/public/cel_expression.h
@@ -34,12 +34,12 @@ class CelExpression {
   // activation contains bindings from parameter names to values
   // arena parameter specifies Arena object where output result and
   // internal data will be allocated.
-  virtual cel_base::StatusOr<CelValue> Evaluate(const Activation& activation,
+  virtual cel_base::StatusOr<CelValue> Evaluate(const BaseActivation& activation,
                                             google::protobuf::Arena* arena) const = 0;
 
   // Trace evaluates expression calling the callback on each sub-tree.
   virtual cel_base::StatusOr<CelValue> Trace(
-      const Activation& activation, google::protobuf::Arena* arena,
+      const BaseActivation& activation, google::protobuf::Arena* arena,
       CelEvaluationListener callback) const = 0;
 };
 

--- a/eval/public/cel_function_provider.cc
+++ b/eval/public/cel_function_provider.cc
@@ -13,7 +13,7 @@ class ActivationFunctionProviderImpl : public CelFunctionProvider {
   ActivationFunctionProviderImpl() {}
   cel_base::StatusOr<const CelFunction*> GetFunction(
       const CelFunctionDescriptor& descriptor,
-      const Activation& activation) const override {
+      const BaseActivation& activation) const override {
     std::vector<const CelFunction*> overloads =
         activation.FindFunctionOverloads(descriptor.name());
 

--- a/eval/public/cel_function_provider.h
+++ b/eval/public/cel_function_provider.h
@@ -20,7 +20,7 @@ class CelFunctionProvider {
   // nullptr is interpreted as no funtion overload matches the descriptor.
   virtual cel_base::StatusOr<const CelFunction*> GetFunction(
       const CelFunctionDescriptor& descriptor,
-      const Activation& activation) const = 0;
+      const BaseActivation& activation) const = 0;
   virtual ~CelFunctionProvider() {}
 };
 

--- a/eval/public/cel_function_registry_test.cc
+++ b/eval/public/cel_function_registry_test.cc
@@ -23,7 +23,7 @@ class NullLazyFunctionProvider : public virtual CelFunctionProvider {
   // Just return nullptr indicating no matching function.
   cel_base::StatusOr<const CelFunction*> GetFunction(
       const CelFunctionDescriptor& desc,
-      const Activation& activation) const override {
+      const BaseActivation& activation) const override {
     return nullptr;
   }
 };


### PR DESCRIPTION
284576129:

BEGIN_PUBLIC
Define an abstract class for Activation.
This would be used by a Wasm context to implement FindValue, as opposed
to maintaining an embedded Activation. Values have unmanaged lifetimes,
meaning if it difficult to add/remove values from an Activation repeatedly.
END_PUBLIC

284290583:

Migrate existing users of the tools/build_defs/golden_test macros to use the new macro location.

284044257:

BEGIN_PUBLIC
Fix parsing bug with raw strings (e.g. r"").
Switch conformance tests to use C++ parser instead of Go parser.
END_PUBLIC

PiperOrigin-RevId: 284576129

Fixes #28 