### PR TITLE
Export of internal changes

### DIFF
--- a/eval/public/BUILD
+++ b/eval/public/BUILD
@@ -573,6 +573,8 @@ cc_library(
         ":cel_function",
         ":cel_options",
         ":cel_value",
+        "//eval/eval:set_util",
+        "@com_google_absl//absl/container:btree",
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
     ],
 )

--- a/eval/public/unknown_function_result_set.cc
+++ b/eval/public/unknown_function_result_set.cc
@@ -2,6 +2,8 @@
 
 #include <type_traits>
 
+#include "absl/container/btree_set.h"
+#include "eval/eval/set_util.h"
 #include "eval/public/cel_function.h"
 #include "eval/public/cel_options.h"
 #include "eval/public/cel_value.h"
@@ -12,147 +14,83 @@ namespace expr {
 namespace runtime {
 namespace {
 
-// Forward declare.
-bool CelValueEqual(const CelValue lhs, const CelValue rhs);
-
-// Default to operator==
-template <typename T>
-bool CelValueEqualImpl(T lhs, T rhs) {
-  return lhs == rhs;
-}
-
-// List equality specialization. Test that the lists are in-order elementwise
-// equal.
-template <>
-bool CelValueEqualImpl<const CelList*>(const CelList* lhs, const CelList* rhs) {
-  if (lhs->size() != rhs->size()) {
-    return false;
-  }
-  for (int i = 0; i < rhs->size(); i++) {
-    if (!CelValueEqual(lhs->operator[](i), rhs->operator[](i))) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Map equality specialization. Compare that two maps have exactly the same
-// key/value pairs.
-template <>
-bool CelValueEqualImpl<const CelMap*>(const CelMap* lhs, const CelMap* rhs) {
-  if (lhs->size() != rhs->size()) {
-    return false;
-  }
-  const CelList* key_set = rhs->ListKeys();
-  for (int i = 0; i < key_set->size(); i++) {
-    CelValue key = key_set->operator[](i);
-    CelValue rhs_value = rhs->operator[](key).value();
-    auto maybe_lhs_value = lhs->operator[](key);
-    if (!maybe_lhs_value.has_value()) {
-      return false;
-    }
-    if (!CelValueEqual(maybe_lhs_value.value(), rhs_value)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Visitor for implementing comparing the underlying value that two CelValues
-// are wrapping. The visitor unwraps the lhs then tries to get the rhs
-// underlying value if it is the same type as the lhs.
-struct LhsCompareVisitor {
-  CelValue rhs;
-
-  LhsCompareVisitor(CelValue rhs) : rhs(rhs) {}
-
-  template <typename T>
-  bool operator()(T lhs_value) {
-    T rhs_value;
-    bool is_same_type = rhs.GetValue(&rhs_value);
-    if (!is_same_type) {
-      return false;
-    }
-    return CelValueEqualImpl<T>(lhs_value, rhs_value);
-  }
-};
-
-// This is a slightly different implementation than provided for the cel
-// evaluator. Differences are:
-//
-// - this implementation doesn't need to support error forwarding in the same
-//   way -- this should only be used for situations when we can invoke the
-//   function. i.e. the function must specify that it consumes errors and/or
-//   unknown sets for them to appear in the arg list.
-// - this implementation defines equality between messages based on ptr identity
-bool CelValueEqual(const CelValue lhs, const CelValue rhs) {
-  if (lhs.type() != rhs.type()) {
-    return false;
-  }
-  return lhs.Visit<bool>(LhsCompareVisitor(rhs));
-}
-
-// Tests that two descriptors are equal (name, receiver call style, arg types).
-//
+// Tests that lhs descriptor is less than (name, receiver call style,
+// arg types).
 // Argument type Any is not treated specially. For example:
-// {"f", false, {kAny}} != {"f", false, {kInt64}}
-bool DescriptorEqual(const CelFunctionDescriptor& lhs,
-                     const CelFunctionDescriptor& rhs) {
-  if (lhs.name() != rhs.name()) {
+// {"f", false, {kAny}} > {"f", false, {kInt64}}
+bool DescriptorLessThan(const CelFunctionDescriptor& lhs,
+                        const CelFunctionDescriptor& rhs) {
+  if (lhs.name() < rhs.name()) {
+    return true;
+  }
+  if (lhs.name() > rhs.name()) {
     return false;
   }
 
-  if (lhs.receiver_style() != rhs.receiver_style()) {
+  if (lhs.receiver_style() < rhs.receiver_style()) {
+    return true;
+  }
+  if (lhs.receiver_style() > rhs.receiver_style()) {
     return false;
   }
 
-  if (lhs.types() != rhs.types()) {
+  if (lhs.types() >= rhs.types()) {
     return false;
   }
 
   return true;
+}
+
+bool UnknownFunctionResultLessThan(const UnknownFunctionResult& lhs,
+                                   const UnknownFunctionResult& rhs) {
+  if (DescriptorLessThan(lhs.descriptor(), rhs.descriptor())) {
+    return true;
+  }
+  if (DescriptorLessThan(rhs.descriptor(), lhs.descriptor())) {
+    return false;
+  }
+
+  if (lhs.arguments().size() < rhs.arguments().size()) {
+    return true;
+  }
+
+  if (lhs.arguments().size() > rhs.arguments().size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < lhs.arguments().size(); i++) {
+    if (CelValueLessThan(lhs.arguments()[i], rhs.arguments()[i])) {
+      return true;
+    }
+    if (CelValueLessThan(rhs.arguments()[i], lhs.arguments()[i])) {
+      return false;
+    }
+  }
+
+  // equal
+  return false;
 }
 
 }  // namespace
 
+bool UnknownFunctionComparator::operator()(
+    const UnknownFunctionResult* lhs, const UnknownFunctionResult* rhs) const {
+  return UnknownFunctionResultLessThan(*lhs, *rhs);
+}
+
 bool UnknownFunctionResult::IsEqualTo(
     const UnknownFunctionResult& other) const {
-  if (!DescriptorEqual(descriptor_, other.descriptor())) {
-    return false;
-  }
-
-  if (arguments_.size() != other.arguments().size()) {
-    return false;
-  }
-
-  for (size_t i = 0; i < arguments_.size(); i++) {
-    if (!CelValueEqual(arguments_[i], other.arguments()[i])) {
-      return false;
-    }
-  }
-
-  return true;
+  return !(UnknownFunctionResultLessThan(*this, other) ||
+           UnknownFunctionResultLessThan(other, *this));
 }
 
 // Implementation for merge constructor.
 UnknownFunctionResultSet::UnknownFunctionResultSet(
     const UnknownFunctionResultSet& lhs, const UnknownFunctionResultSet& rhs)
     : unknown_function_results_(lhs.unknown_function_results()) {
-  unknown_function_results_.reserve(lhs.unknown_function_results().size() +
-                                    rhs.unknown_function_results().size());
   for (const UnknownFunctionResult* call : rhs.unknown_function_results()) {
-    Add(call);
+    unknown_function_results_.insert(call);
   }
-}
-
-void UnknownFunctionResultSet::Add(const UnknownFunctionResult* result) {
-  for (const UnknownFunctionResult* existing_result :
-       unknown_function_results()) {
-    if (result->IsEqualTo(*existing_result)) {
-      return;
-    }
-  }
-  unknown_function_results_.push_back(result);
 }
 
 }  // namespace runtime

--- a/eval/public/unknown_function_result_set_test.cc
+++ b/eval/public/unknown_function_result_set_test.cc
@@ -35,6 +35,12 @@ CelFunctionDescriptor kTwoInt("TwoInt", false,
 
 CelFunctionDescriptor kOneInt("OneInt", false, {CelValue::Type::kInt64});
 
+// Helper to confirm the set comparator works.
+bool IsLessThan(const UnknownFunctionResult& lhs,
+                const UnknownFunctionResult& rhs) {
+  return UnknownFunctionComparator()(&lhs, &rhs);
+}
+
 TEST(UnknownFunctionResult, ArgumentCapture) {
   UnknownFunctionResult call1(
       kTwoInt, /*expr_id=*/0,
@@ -54,6 +60,8 @@ TEST(UnknownFunctionResult, Equals) {
       {CelValue::CreateInt64(1), CelValue::CreateInt64(2)});
 
   EXPECT_TRUE(call1.IsEqualTo(call2));
+  EXPECT_FALSE(IsLessThan(call1, call2));
+  EXPECT_FALSE(IsLessThan(call2, call1));
 
   UnknownFunctionResult call3(kOneInt, /*expr_id=*/0,
                               {CelValue::CreateInt64(1)});
@@ -73,6 +81,7 @@ TEST(UnknownFunctionResult, InequalDescriptor) {
                               {CelValue::CreateInt64(1)});
 
   EXPECT_FALSE(call1.IsEqualTo(call2));
+  EXPECT_TRUE(IsLessThan(call2, call1));
 
   CelFunctionDescriptor one_uint("OneInt", false, {CelValue::Type::kUint64});
 
@@ -83,6 +92,7 @@ TEST(UnknownFunctionResult, InequalDescriptor) {
                               {CelValue::CreateUint64(1)});
 
   EXPECT_FALSE(call3.IsEqualTo(call4));
+  EXPECT_TRUE(IsLessThan(call3, call4));
 }
 
 TEST(UnknownFunctionResult, InequalArgs) {
@@ -95,6 +105,7 @@ TEST(UnknownFunctionResult, InequalArgs) {
       {CelValue::CreateInt64(1), CelValue::CreateInt64(3)});
 
   EXPECT_FALSE(call1.IsEqualTo(call2));
+  EXPECT_TRUE(IsLessThan(call1, call2));
 
   UnknownFunctionResult call3(
       kTwoInt, /*expr_id=*/0,
@@ -104,6 +115,7 @@ TEST(UnknownFunctionResult, InequalArgs) {
                               {CelValue::CreateInt64(1)});
 
   EXPECT_FALSE(call3.IsEqualTo(call4));
+  EXPECT_TRUE(IsLessThan(call4, call3));
 }
 
 TEST(UnknownFunctionResult, ListsEqual) {
@@ -143,6 +155,7 @@ TEST(UnknownFunctionResult, ListsDifferentSizes) {
 
   // [1, 2] == [1, 2, 3]
   EXPECT_FALSE(call1.IsEqualTo(call2));
+  EXPECT_TRUE(IsLessThan(call1, call2));
 }
 
 TEST(UnknownFunctionResult, ListsDifferentMembers) {
@@ -161,6 +174,7 @@ TEST(UnknownFunctionResult, ListsDifferentMembers) {
 
   // [1, 2] == [2, 2]
   EXPECT_FALSE(call1.IsEqualTo(call2));
+  EXPECT_TRUE(IsLessThan(call1, call2));
 }
 
 TEST(UnknownFunctionResult, MapsEqual) {
@@ -205,6 +219,7 @@ TEST(UnknownFunctionResult, MapsDifferentSizes) {
 
   // {1: 2, 2: 4} == {1: 2, 2: 4, 3: 6}
   EXPECT_FALSE(call1.IsEqualTo(call2));
+  EXPECT_TRUE(IsLessThan(call1, call2));
 }
 
 TEST(UnknownFunctionResult, MapsDifferentElements) {
@@ -240,8 +255,10 @@ TEST(UnknownFunctionResult, MapsDifferentElements) {
 
   // {1: 2, 2: 4, 3: 6} == {1: 2, 2: 4, 4: 8}
   EXPECT_FALSE(call1.IsEqualTo(call2));
+  EXPECT_TRUE(IsLessThan(call1, call2));
   // {1: 2, 2: 4, 3: 6} == {1: 2, 2: 4, 3: 5}
   EXPECT_FALSE(call1.IsEqualTo(call3));
+  EXPECT_TRUE(IsLessThan(call3, call1));
 }
 
 TEST(UnknownFunctionResult, Messages) {
@@ -279,7 +296,9 @@ TEST(UnknownFunctionResult, AnyDescriptor) {
                                     {CelValue::CreateUint64(2)});
 
   EXPECT_FALSE(callAnyInt1.IsEqualTo(callInt));
+  EXPECT_TRUE(IsLessThan(callAnyInt1, callInt));
   EXPECT_FALSE(callAnyInt1.IsEqualTo(callAnyUint));
+  EXPECT_TRUE(IsLessThan(callAnyInt1, callAnyUint));
   EXPECT_TRUE(callAnyInt1.IsEqualTo(callAnyInt2));
 }
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,61 @@
+load(
+    "@com_github_google_flatbuffers//:build_defs.bzl",
+    "flatbuffer_library_public",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "flatbuffers_backed_impl",
+    srcs = [
+        "flatbuffers_backed_impl.cc",
+    ],
+    hdrs = [
+        "flatbuffers_backed_impl.h",
+    ],
+    copts = ["-std=c++14"],
+    deps = [
+        "//eval/public:cel_value",
+        "@com_github_google_flatbuffers//:flatbuffers",
+    ],
+)
+
+flatbuffer_library_public(
+    name = "flatbuffers_test",
+    srcs = ["testdata/flatbuffers.fbs"],
+    outs = ["testdata/flatbuffers_generated.h"],
+    language_flag = "-c",
+    reflection_name = "flatbuffers_reflection",
+)
+
+cc_library(
+    name = "flatbuffers_test_cc",
+    srcs = [":flatbuffers_test"],
+    hdrs = [":flatbuffers_test"],
+    copts = ["-std=c++14"],
+    features = ["-parse_headers"],
+    linkstatic = True,
+    deps = ["@com_github_google_flatbuffers//:runtime_cc"],
+)
+
+cc_test(
+    name = "flatbuffers_backed_impl_test",
+    size = "small",
+    srcs = [
+        "flatbuffers_backed_impl_test.cc",
+    ],
+    copts = ["-std=c++14"],
+    data = [
+        ":flatbuffers_reflection_out",
+    ],
+    deps = [
+        ":flatbuffers_backed_impl",
+        ":flatbuffers_test_cc",
+        "@com_github_google_flatbuffers//:flatbuffers",
+        "@com_github_google_googletest//:gtest_main",
+    ],
+)

--- a/tools/flatbuffers_backed_impl.cc
+++ b/tools/flatbuffers_backed_impl.cc
@@ -1,0 +1,310 @@
+#include "tools/flatbuffers_backed_impl.h"
+
+#include <algorithm>
+
+#include "flatbuffers/flatbuffers.h"
+
+namespace google {
+namespace api {
+namespace expr {
+namespace runtime {
+
+namespace {
+
+CelValue CreateValue(int64_t value) { return CelValue::CreateInt64(value); }
+CelValue CreateValue(uint64_t value) { return CelValue::CreateUint64(value); }
+CelValue CreateValue(double value) { return CelValue::CreateDouble(value); }
+CelValue CreateValue(bool value) { return CelValue::CreateBool(value); }
+
+template <typename T, typename U>
+class FlatBuffersListImpl : public CelList {
+ public:
+  FlatBuffersListImpl(const flatbuffers::Table& table,
+                      const reflection::Field& field)
+      : list_(table.GetPointer<const flatbuffers::Vector<T>*>(field.offset())) {
+  }
+  int size() const override { return list_ ? list_->size() : 0; }
+  CelValue operator[](int index) const override {
+    return CreateValue(static_cast<U>(list_->Get(index)));
+  }
+
+ private:
+  const flatbuffers::Vector<T>* list_;
+};
+
+class StringListImpl : public CelList {
+ public:
+  StringListImpl(
+      const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>* list)
+      : list_(list) {}
+  int size() const override { return list_ ? list_->size() : 0; }
+  CelValue operator[](int index) const override {
+    auto value = list_->Get(index);
+    return CelValue::CreateStringView(
+        absl::string_view(value->c_str(), value->size()));
+  }
+
+ private:
+  const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>* list_;
+};
+
+class ObjectListImpl : public CelList {
+ public:
+  ObjectListImpl(
+      const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::Table>>* list,
+      const reflection::Schema& schema, const reflection::Object& object,
+      google::protobuf::Arena* arena)
+      : arena_(arena), list_(list), schema_(schema), object_(object) {}
+  int size() const override { return list_ ? list_->size() : 0; }
+  CelValue operator[](int index) const override {
+    auto value = list_->Get(index);
+    return CelValue::CreateMap(google::protobuf::Arena::Create<FlatBuffersMapImpl>(
+        arena_, *value, schema_, object_, arena_));
+  }
+
+ private:
+  google::protobuf::Arena* arena_;
+  const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::Table>>* list_;
+  const reflection::Schema& schema_;
+  const reflection::Object& object_;
+};
+
+class ObjectStringIndexedMapImpl : public CelMap {
+ public:
+  ObjectStringIndexedMapImpl(
+      const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::Table>>* list,
+      const reflection::Schema& schema, const reflection::Object& object,
+      const reflection::Field& index, google::protobuf::Arena* arena)
+      : arena_(arena),
+        list_(list),
+        schema_(schema),
+        object_(object),
+        index_(index) {
+    keys_.parent_ = this;
+  }
+  int size() const override { return list_ ? list_->size() : 0; }
+  absl::optional<CelValue> operator[](CelValue cel_key) const override {
+    if (!cel_key.IsString()) {
+      return {};
+    }
+    const absl::string_view key = cel_key.StringOrDie().value();
+    const auto it = std::lower_bound(
+        list_->begin(), list_->end(), key,
+        [this](const flatbuffers::Table* t, const absl::string_view key) {
+          auto value = flatbuffers::GetFieldS(*t, index_);
+          auto sv = value ? absl::string_view(value->c_str(), value->size())
+                          : absl::string_view();
+          return sv < key;
+        });
+    if (it != list_->end()) {
+      auto value = flatbuffers::GetFieldS(**it, index_);
+      auto sv = value ? absl::string_view(value->c_str(), value->size())
+                      : absl::string_view();
+      if (sv == key) {
+        return CelValue::CreateMap(google::protobuf::Arena::Create<FlatBuffersMapImpl>(
+            arena_, **it, schema_, object_, arena_));
+      }
+    }
+    return {};
+  }
+  const CelList* ListKeys() const override { return &keys_; }
+
+ private:
+  struct KeyList : public CelList {
+    int size() const override { return parent_->size(); }
+    CelValue operator[](int index) const override {
+      auto value = flatbuffers::GetFieldS(*(parent_->list_->Get(index)),
+                                          parent_->index_);
+      if (value == nullptr) {
+        return CelValue::CreateStringView(absl::string_view());
+      }
+      return CelValue::CreateStringView(
+          absl::string_view(value->c_str(), value->size()));
+    }
+    ObjectStringIndexedMapImpl* parent_;
+  };
+  google::protobuf::Arena* arena_;
+  const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::Table>>* list_;
+  const reflection::Schema& schema_;
+  const reflection::Object& object_;
+  const reflection::Field& index_;
+  KeyList keys_;
+};
+
+// Detects a "key" field of the type string.
+const reflection::Field* findStringKeyField(const reflection::Object& object) {
+  for (const auto field : *object.fields()) {
+    if (field->key() && field->type()->base_type() == reflection::String) {
+      return field;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+absl::optional<CelValue> FlatBuffersMapImpl::operator[](
+    CelValue cel_key) const {
+  if (!cel_key.IsString()) {
+    return {};
+  }
+  auto field = keys_.fields_->LookupByKey(cel_key.StringOrDie().value().data());
+  if (field == nullptr) {
+    return {};
+  }
+  switch (field->type()->base_type()) {
+    case reflection::Byte:
+      return CelValue::CreateInt64(
+          flatbuffers::GetFieldI<int8_t>(table_, *field));
+    case reflection::Short:
+      return CelValue::CreateInt64(
+          flatbuffers::GetFieldI<int16_t>(table_, *field));
+    case reflection::Int:
+      return CelValue::CreateInt64(
+          flatbuffers::GetFieldI<int32_t>(table_, *field));
+    case reflection::Long:
+      return CelValue::CreateInt64(
+          flatbuffers::GetFieldI<int64_t>(table_, *field));
+    case reflection::UByte:
+      return CelValue::CreateUint64(
+          flatbuffers::GetFieldI<uint8_t>(table_, *field));
+    case reflection::UShort:
+      return CelValue::CreateUint64(
+          flatbuffers::GetFieldI<uint16_t>(table_, *field));
+    case reflection::UInt:
+      return CelValue::CreateUint64(
+          flatbuffers::GetFieldI<uint32_t>(table_, *field));
+    case reflection::ULong:
+      return CelValue::CreateUint64(
+          flatbuffers::GetFieldI<uint64_t>(table_, *field));
+    case reflection::Float:
+      return CelValue::CreateDouble(
+          flatbuffers::GetFieldF<float>(table_, *field));
+    case reflection::Double:
+      return CelValue::CreateDouble(
+          flatbuffers::GetFieldF<double>(table_, *field));
+    case reflection::Bool:
+      return CelValue::CreateBool(
+          flatbuffers::GetFieldI<int8_t>(table_, *field));
+    case reflection::String: {
+      auto value = flatbuffers::GetFieldS(table_, *field);
+      if (value == nullptr) {
+        return CelValue::CreateStringView(absl::string_view());
+      }
+      return CelValue::CreateStringView(
+          absl::string_view(value->c_str(), value->size()));
+    }
+    case reflection::Obj: {
+      const auto* field_schema = schema_.objects()->Get(field->type()->index());
+      const auto* field_table = flatbuffers::GetFieldT(table_, *field);
+      if (field_table == nullptr) {
+        return CelValue::CreateNull();
+      }
+      if (field_schema) {
+        return CelValue::CreateMap(google::protobuf::Arena::Create<FlatBuffersMapImpl>(
+            arena_, *field_table, schema_, *field_schema, arena_));
+      }
+      break;
+    }
+    case reflection::Vector: {
+      switch (field->type()->element()) {
+        case reflection::Byte:
+        case reflection::UByte: {
+          const auto* field_table = flatbuffers::GetFieldAnyV(table_, *field);
+          if (field_table == nullptr) {
+            return CelValue::CreateBytesView(absl::string_view());
+          }
+          return CelValue::CreateBytesView(absl::string_view(
+              reinterpret_cast<const char*>(field_table->Data()),
+              field_table->size()));
+        }
+        case reflection::Short:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<int16_t, int64_t>>(
+                  arena_, table_, *field));
+        case reflection::Int:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<int32_t, int64_t>>(
+                  arena_, table_, *field));
+        case reflection::Long:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<int64_t, int64_t>>(
+                  arena_, table_, *field));
+        case reflection::UShort:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<uint16_t, uint64_t>>(
+                  arena_, table_, *field));
+        case reflection::UInt:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<uint32_t, uint64_t>>(
+                  arena_, table_, *field));
+        case reflection::ULong:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<uint64_t, uint64_t>>(
+                  arena_, table_, *field));
+        case reflection::Float:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<float, double>>(
+                  arena_, table_, *field));
+        case reflection::Double:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<double, double>>(
+                  arena_, table_, *field));
+        case reflection::Bool:
+          return CelValue::CreateList(
+              google::protobuf::Arena::Create<FlatBuffersListImpl<uint8_t, bool>>(
+                  arena_, table_, *field));
+        case reflection::String:
+          return CelValue::CreateList(google::protobuf::Arena::Create<StringListImpl>(
+              arena_, table_.GetPointer<const flatbuffers::Vector<
+                          flatbuffers::Offset<flatbuffers::String>>*>(
+                          field->offset())));
+        case reflection::Obj: {
+          const auto* field_schema =
+              schema_.objects()->Get(field->type()->index());
+          if (field_schema) {
+            const auto* index = findStringKeyField(*field_schema);
+            if (index) {
+              return CelValue::CreateMap(
+                  google::protobuf::Arena::Create<ObjectStringIndexedMapImpl>(
+                      arena_,
+                      table_.GetPointer<const flatbuffers::Vector<
+                          flatbuffers::Offset<flatbuffers::Table>>*>(
+                          field->offset()),
+                      schema_, *field_schema, *index, arena_));
+            } else {
+              return CelValue::CreateList(google::protobuf::Arena::Create<ObjectListImpl>(
+                  arena_,
+                  table_.GetPointer<const flatbuffers::Vector<
+                      flatbuffers::Offset<flatbuffers::Table>>*>(
+                      field->offset()),
+                  schema_, *field_schema, arena_));
+            }
+          }
+          break;
+        }
+        default:
+          // Unsupported vector base types
+          return {};
+      }
+      break;
+    }
+    default:
+      // Unsupported types: enums, unions, arrays
+      return {};
+  }
+  return {};
+}
+
+const CelMap* CreateFlatBuffersBackedObject(const uint8_t* flatbuf,
+                                            const reflection::Schema& schema,
+                                            google::protobuf::Arena* arena) {
+  return google::protobuf::Arena::Create<const FlatBuffersMapImpl>(
+      arena, *flatbuffers::GetAnyRoot(flatbuf), schema, *schema.root_table(),
+      arena);
+}
+
+}  // namespace runtime
+}  // namespace expr
+}  // namespace api
+}  // namespace google

--- a/tools/flatbuffers_backed_impl.h
+++ b/tools/flatbuffers_backed_impl.h
@@ -1,0 +1,51 @@
+#ifndef THIRD_PARTY_CEL_CPP_TOOLS_FLATBUFFERS_BACKED_IMPL_H_
+#define THIRD_PARTY_CEL_CPP_TOOLS_FLATBUFFERS_BACKED_IMPL_H_
+
+#include "eval/public/cel_value.h"
+#include "flatbuffers/reflection.h"
+
+namespace google {
+namespace api {
+namespace expr {
+namespace runtime {
+
+class FlatBuffersMapImpl : public CelMap {
+ public:
+  FlatBuffersMapImpl(const flatbuffers::Table& table,
+                     const reflection::Schema& schema,
+                     const reflection::Object& object, google::protobuf::Arena* arena)
+      : arena_(arena), table_(table), schema_(schema) {
+    keys_.fields_ = object.fields();
+  }
+  int size() const override { return keys_.fields_->size(); }
+  absl::optional<CelValue> operator[](CelValue cel_key) const override;
+  const CelList* ListKeys() const override { return &keys_; }
+
+ private:
+  struct FieldList : public CelList {
+    int size() const override { return fields_->size(); }
+    CelValue operator[](int index) const override {
+      auto name = fields_->Get(index)->name();
+      return CelValue::CreateStringView(
+          absl::string_view(name->c_str(), name->size()));
+    }
+    const flatbuffers::Vector<flatbuffers::Offset<reflection::Field>>* fields_;
+  };
+  FieldList keys_;
+  google::protobuf::Arena* arena_;
+  const flatbuffers::Table& table_;
+  const reflection::Schema& schema_;
+};
+
+// Factory method to instantiate a CelValue on the arena for flatbuffer object
+// from a reflection schema.
+const CelMap* CreateFlatBuffersBackedObject(const uint8_t* flatbuf,
+                                            const reflection::Schema& schema,
+                                            google::protobuf::Arena* arena);
+
+}  // namespace runtime
+}  // namespace expr
+}  // namespace api
+}  // namespace google
+
+#endif  // THIRD_PARTY_CEL_CPP_TOOLS_FLATBUFFERS_BACKED_IMPL_H_

--- a/tools/flatbuffers_backed_impl_test.cc
+++ b/tools/flatbuffers_backed_impl_test.cc
@@ -1,0 +1,543 @@
+#include "tools/flatbuffers_backed_impl.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "flatbuffers/idl.h"
+#include "flatbuffers/reflection.h"
+
+namespace google {
+namespace api {
+namespace expr {
+namespace runtime {
+
+namespace {
+
+using google::protobuf::Arena;
+
+constexpr char kReflectionBufferPath[] =
+    "tools/flatbuffers.bfbs";
+
+constexpr absl::string_view kByteField = "f_byte";
+constexpr absl::string_view kUbyteField = "f_ubyte";
+constexpr absl::string_view kShortField = "f_short";
+constexpr absl::string_view kUshortField = "f_ushort";
+constexpr absl::string_view kIntField = "f_int";
+constexpr absl::string_view kUintField = "f_uint";
+constexpr absl::string_view kLongField = "f_long";
+constexpr absl::string_view kUlongField = "f_ulong";
+constexpr absl::string_view kFloatField = "f_float";
+constexpr absl::string_view kDoubleField = "f_double";
+constexpr absl::string_view kBoolField = "f_bool";
+constexpr absl::string_view kStringField = "f_string";
+constexpr absl::string_view kObjField = "f_obj";
+
+constexpr absl::string_view kUnknownField = "f_unknown";
+
+constexpr absl::string_view kBytesField = "r_byte";
+constexpr absl::string_view kUbytesField = "r_ubyte";
+constexpr absl::string_view kShortsField = "r_short";
+constexpr absl::string_view kUshortsField = "r_ushort";
+constexpr absl::string_view kIntsField = "r_int";
+constexpr absl::string_view kUintsField = "r_uint";
+constexpr absl::string_view kLongsField = "r_long";
+constexpr absl::string_view kUlongsField = "r_ulong";
+constexpr absl::string_view kFloatsField = "r_float";
+constexpr absl::string_view kDoublesField = "r_double";
+constexpr absl::string_view kBoolsField = "r_bool";
+constexpr absl::string_view kStringsField = "r_string";
+constexpr absl::string_view kObjsField = "r_obj";
+constexpr absl::string_view kIndexedField = "r_indexed";
+
+const int64_t kNumFields = 27;
+
+class FlatBuffersTest : public testing::Test {
+ public:
+  FlatBuffersTest() {
+    EXPECT_TRUE(
+        flatbuffers::LoadFile(kReflectionBufferPath, true, &schema_file_));
+    flatbuffers::Verifier verifier(
+        reinterpret_cast<const uint8_t*>(schema_file_.data()),
+        schema_file_.size());
+    EXPECT_TRUE(reflection::VerifySchemaBuffer(verifier));
+    EXPECT_TRUE(parser_.Deserialize(
+        reinterpret_cast<const uint8_t*>(schema_file_.data()),
+        schema_file_.size()));
+    schema_ = reflection::GetSchema(schema_file_.data());
+  }
+  const CelMap& loadJson(std::string data) {
+    EXPECT_TRUE(parser_.Parse(data.data()));
+    const CelMap* value = CreateFlatBuffersBackedObject(
+        parser_.builder_.GetBufferPointer(), *schema_, &arena_);
+    EXPECT_NE(nullptr, value);
+    EXPECT_EQ(kNumFields, value->size());
+    const CelList* keys = value->ListKeys();
+    EXPECT_NE(nullptr, keys);
+    EXPECT_EQ(kNumFields, keys->size());
+    EXPECT_TRUE((*keys)[2].IsString());
+    return *value;
+  }
+
+ protected:
+  std::string schema_file_;
+  flatbuffers::Parser parser_;
+  const reflection::Schema* schema_;
+  google::protobuf::Arena arena_;
+};
+
+TEST_F(FlatBuffersTest, PrimitiveFields) {
+  const CelMap& value = loadJson(R"({
+              f_byte: -1,
+              f_ubyte: 1,
+              f_short: -2,
+              f_ushort: 2,
+              f_int: -3,
+              f_uint: 3,
+              f_long: -4,
+              f_ulong: 4,
+              f_float: 5.0,
+              f_double: 6.0,
+              f_bool: false,
+              f_string: "test"
+              })");
+  // byte
+  {
+    auto f = value[CelValue::CreateStringView(kByteField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsInt64());
+    EXPECT_EQ(-1, f.value().Int64OrDie());
+  }
+  {
+    auto uf = value[CelValue::CreateStringView(kUbyteField)];
+    EXPECT_TRUE(uf.has_value());
+    EXPECT_TRUE(uf.value().IsUint64());
+    EXPECT_EQ(1, uf.value().Uint64OrDie());
+  }
+  // short
+  {
+    auto f = value[CelValue::CreateStringView(kShortField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsInt64());
+    EXPECT_EQ(-2, f.value().Int64OrDie());
+  }
+  {
+    auto uf = value[CelValue::CreateStringView(kUshortField)];
+    EXPECT_TRUE(uf.has_value());
+    EXPECT_TRUE(uf.value().IsUint64());
+    EXPECT_EQ(2, uf.value().Uint64OrDie());
+  }
+  // int
+  {
+    auto f = value[CelValue::CreateStringView(kIntField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsInt64());
+    EXPECT_EQ(-3, f.value().Int64OrDie());
+  }
+  {
+    auto uf = value[CelValue::CreateStringView(kUintField)];
+    EXPECT_TRUE(uf.has_value());
+    EXPECT_TRUE(uf.value().IsUint64());
+    EXPECT_EQ(3, uf.value().Uint64OrDie());
+  }
+  // long
+  {
+    auto f = value[CelValue::CreateStringView(kLongField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsInt64());
+    EXPECT_EQ(-4, f.value().Int64OrDie());
+  }
+  {
+    auto uf = value[CelValue::CreateStringView(kUlongField)];
+    EXPECT_TRUE(uf.has_value());
+    EXPECT_TRUE(uf.value().IsUint64());
+    EXPECT_EQ(4, uf.value().Uint64OrDie());
+  }
+  // float and double
+  {
+    auto f = value[CelValue::CreateStringView(kFloatField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsDouble());
+    EXPECT_EQ(5.0, f.value().DoubleOrDie());
+  }
+  {
+    auto f = value[CelValue::CreateStringView(kDoubleField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsDouble());
+    EXPECT_EQ(6.0, f.value().DoubleOrDie());
+  }
+  // bool
+  {
+    auto f = value[CelValue::CreateStringView(kBoolField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsBool());
+    EXPECT_EQ(false, f.value().BoolOrDie());
+  }
+  // string
+  {
+    auto f = value[CelValue::CreateStringView(kStringField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsString());
+    EXPECT_EQ("test", f.value().StringOrDie().value());
+  }
+  // missing field
+  {
+    auto f = value[CelValue::CreateInt64(1)];
+    EXPECT_FALSE(f.has_value());
+  }
+  {
+    auto f = value[CelValue::CreateStringView(kUnknownField)];
+    EXPECT_FALSE(f.has_value());
+  }
+}
+
+TEST_F(FlatBuffersTest, PrimitiveFieldDefaults) {
+  const CelMap& value = loadJson("{}");
+  // byte
+  {
+    auto f = value[CelValue::CreateStringView(kByteField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsInt64());
+    EXPECT_EQ(0, f.value().Int64OrDie());
+  }
+  // short
+  {
+    auto f = value[CelValue::CreateStringView(kShortField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsInt64());
+    EXPECT_EQ(150, f.value().Int64OrDie());
+  }
+  // bool
+  {
+    auto f = value[CelValue::CreateStringView(kBoolField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsBool());
+    EXPECT_EQ(true, f.value().BoolOrDie());
+  }
+  // string
+  {
+    auto f = value[CelValue::CreateStringView(kStringField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsString());
+    EXPECT_EQ("", f.value().StringOrDie().value());
+  }
+}
+
+TEST_F(FlatBuffersTest, ObjectField) {
+  const CelMap& value = loadJson(R"({
+                                    f_obj: {
+                                      f_string: "entry",
+                                      f_int: 16
+                                    }
+                                    })");
+  auto f = value[CelValue::CreateStringView(kObjField)];
+  EXPECT_TRUE(f.has_value());
+  EXPECT_TRUE(f.value().IsMap());
+  const CelMap& m = *f.value().MapOrDie();
+  EXPECT_EQ(2, m.size());
+  {
+    auto mf = m[CelValue::CreateStringView(kStringField)];
+    EXPECT_TRUE(mf.has_value());
+    EXPECT_TRUE(mf.value().IsString());
+    EXPECT_EQ("entry", mf.value().StringOrDie().value());
+  }
+  {
+    auto mf = m[CelValue::CreateStringView(kIntField)];
+    EXPECT_TRUE(mf.has_value());
+    EXPECT_TRUE(mf.value().IsInt64());
+    EXPECT_EQ(16, mf.value().Int64OrDie());
+  }
+}
+
+TEST_F(FlatBuffersTest, ObjectFieldDefault) {
+  const CelMap& value = loadJson("{}");
+  auto f = value[CelValue::CreateStringView(kObjField)];
+  EXPECT_TRUE(f.has_value());
+  EXPECT_TRUE(f.value().IsNull());
+}
+
+TEST_F(FlatBuffersTest, PrimitiveVectorFields) {
+  const CelMap& value = loadJson(R"({
+              r_byte: [-97],
+              r_ubyte: [97, 98, 99],
+              r_short: [-2],
+              r_ushort: [2],
+              r_int: [-3],
+              r_uint: [3],
+              r_long: [-4],
+              r_ulong: [4],
+              r_float: [5.0],
+              r_double: [6.0],
+              r_bool: [false],
+              r_string: ["test"]
+              })");
+  // byte
+  {
+    auto f = value[CelValue::CreateStringView(kBytesField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsBytes());
+    EXPECT_EQ("\x9F", f.value().BytesOrDie().value());
+  }
+  {
+    auto uf = value[CelValue::CreateStringView(kUbytesField)];
+    EXPECT_TRUE(uf.has_value());
+    EXPECT_TRUE(uf.value().IsBytes());
+    EXPECT_EQ("abc", uf.value().BytesOrDie().value());
+  }
+  // short
+  {
+    auto f = value[CelValue::CreateStringView(kShortsField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsList());
+    const CelList& l = *f.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(-2, l[0].Int64OrDie());
+  }
+  {
+    auto uf = value[CelValue::CreateStringView(kUshortsField)];
+    EXPECT_TRUE(uf.has_value());
+    EXPECT_TRUE(uf.value().IsList());
+    const CelList& l = *uf.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(2, l[0].Uint64OrDie());
+  }
+  // int
+  {
+    auto f = value[CelValue::CreateStringView(kIntsField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsList());
+    const CelList& l = *f.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(-3, l[0].Int64OrDie());
+  }
+  {
+    auto uf = value[CelValue::CreateStringView(kUintsField)];
+    EXPECT_TRUE(uf.has_value());
+    EXPECT_TRUE(uf.value().IsList());
+    const CelList& l = *uf.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(3, l[0].Uint64OrDie());
+  }
+  // long
+  {
+    auto f = value[CelValue::CreateStringView(kLongsField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsList());
+    const CelList& l = *f.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(-4, l[0].Int64OrDie());
+  }
+  {
+    auto uf = value[CelValue::CreateStringView(kUlongsField)];
+    EXPECT_TRUE(uf.has_value());
+    EXPECT_TRUE(uf.value().IsList());
+    const CelList& l = *uf.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(4, l[0].Uint64OrDie());
+  }
+  // float and double
+  {
+    auto f = value[CelValue::CreateStringView(kFloatsField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsList());
+    const CelList& l = *f.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(5.0, l[0].DoubleOrDie());
+  }
+  {
+    auto f = value[CelValue::CreateStringView(kDoublesField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsList());
+    const CelList& l = *f.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(6.0, l[0].DoubleOrDie());
+  }
+  // bool
+  {
+    auto f = value[CelValue::CreateStringView(kBoolsField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsList());
+    const CelList& l = *f.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ(false, l[0].BoolOrDie());
+  }
+  // string
+  {
+    auto f = value[CelValue::CreateStringView(kStringsField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsList());
+    const CelList& l = *f.value().ListOrDie();
+    EXPECT_EQ(1, l.size());
+    EXPECT_EQ("test", l[0].StringOrDie().value());
+  }
+}
+
+TEST_F(FlatBuffersTest, ObjectVectorField) {
+  const CelMap& value = loadJson(R"({
+                                    r_obj: [{
+                                      f_string: "entry",
+                                      f_int: 16
+                                    },{
+                                      f_int: 32
+                                    }]
+                                    })");
+  auto f = value[CelValue::CreateStringView(kObjsField)];
+  EXPECT_TRUE(f.has_value());
+  EXPECT_TRUE(f.value().IsList());
+  const CelList& l = *f.value().ListOrDie();
+  EXPECT_EQ(2, l.size());
+  {
+    EXPECT_TRUE(l[0].IsMap());
+    const CelMap& m = *l[0].MapOrDie();
+    EXPECT_EQ(2, m.size());
+    {
+      auto mf = m[CelValue::CreateStringView(kStringField)];
+      EXPECT_TRUE(mf.has_value());
+      EXPECT_TRUE(mf.value().IsString());
+      EXPECT_EQ("entry", mf.value().StringOrDie().value());
+    }
+    {
+      auto mf = m[CelValue::CreateStringView(kIntField)];
+      EXPECT_TRUE(mf.has_value());
+      EXPECT_TRUE(mf.value().IsInt64());
+      EXPECT_EQ(16, mf.value().Int64OrDie());
+    }
+  }
+  {
+    EXPECT_TRUE(l[1].IsMap());
+    const CelMap& m = *l[1].MapOrDie();
+    EXPECT_EQ(2, m.size());
+    {
+      auto mf = m[CelValue::CreateStringView(kStringField)];
+      EXPECT_TRUE(mf.has_value());
+      EXPECT_TRUE(mf.value().IsString());
+      EXPECT_EQ("", mf.value().StringOrDie().value());
+    }
+    {
+      auto mf = m[CelValue::CreateStringView(kIntField)];
+      EXPECT_TRUE(mf.has_value());
+      EXPECT_TRUE(mf.value().IsInt64());
+      EXPECT_EQ(32, mf.value().Int64OrDie());
+    }
+  }
+}
+
+TEST_F(FlatBuffersTest, VectorFieldDefaults) {
+  const CelMap& value = loadJson("{}");
+  for (const auto field : std::vector<absl::string_view>{
+           kIntsField, kBoolsField, kStringsField, kObjsField}) {
+    auto f = value[CelValue::CreateStringView(field)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsList());
+    const CelList& l = *f.value().ListOrDie();
+    EXPECT_EQ(0, l.size());
+  }
+
+  {
+    auto f = value[CelValue::CreateStringView(kIndexedField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsMap());
+    const CelMap& m = *f.value().MapOrDie();
+    EXPECT_EQ(0, m.size());
+    EXPECT_EQ(0, m.ListKeys()->size());
+  }
+
+  {
+    auto f = value[CelValue::CreateStringView(kBytesField)];
+    EXPECT_TRUE(f.has_value());
+    EXPECT_TRUE(f.value().IsBytes());
+    EXPECT_EQ("", f.value().BytesOrDie().value());
+  }
+}
+
+TEST_F(FlatBuffersTest, IndexedObjectVectorField) {
+  const CelMap& value = loadJson(R"({
+                                    r_indexed: [
+                                    {
+                                      f_string: "a",
+                                      f_int: 16
+                                    },
+                                    {
+                                      f_string: "b",
+                                      f_int: 32
+                                    },
+                                    {
+                                      f_string: "c",
+                                      f_int: 64
+                                    },
+                                    {
+                                      f_string: "d",
+                                      f_int: 128
+                                    }
+                                    ]
+                                    })");
+  auto f = value[CelValue::CreateStringView(kIndexedField)];
+  EXPECT_TRUE(f.has_value());
+  EXPECT_TRUE(f.value().IsMap());
+  const CelMap& m = *f.value().MapOrDie();
+  EXPECT_EQ(4, m.size());
+  const CelList& l = *m.ListKeys();
+  EXPECT_EQ(4, l.size());
+  EXPECT_TRUE(l[0].IsString());
+  EXPECT_TRUE(l[1].IsString());
+  EXPECT_TRUE(l[2].IsString());
+  EXPECT_TRUE(l[3].IsString());
+  std::string a = "a";
+  std::string b = "b";
+  std::string c = "c";
+  std::string d = "d";
+  EXPECT_EQ(a, l[0].StringOrDie().value());
+  EXPECT_EQ(b, l[1].StringOrDie().value());
+  EXPECT_EQ(c, l[2].StringOrDie().value());
+  EXPECT_EQ(d, l[3].StringOrDie().value());
+
+  for (const std::string& key : std::vector<std::string>{a, b, c, d}) {
+    auto v = m[CelValue::CreateString(&key)];
+    EXPECT_TRUE(v.has_value());
+    const CelMap& vm = *v.value().MapOrDie();
+    EXPECT_EQ(2, vm.size());
+    auto vf = vm[CelValue::CreateStringView(kStringField)];
+    EXPECT_TRUE(vf.has_value());
+    EXPECT_TRUE(vf.value().IsString());
+    EXPECT_EQ(key, vf.value().StringOrDie().value());
+    auto vi = vm[CelValue::CreateStringView(kIntField)];
+    EXPECT_TRUE(vi.has_value());
+    EXPECT_TRUE(vi.value().IsInt64());
+  }
+
+  {
+    std::string bb = "bb";
+    std::string dd = "dd";
+    EXPECT_FALSE(m[CelValue::CreateString(&bb)].has_value());
+    EXPECT_FALSE(m[CelValue::CreateString(&dd)].has_value());
+    EXPECT_FALSE(
+        m[CelValue::CreateStringView(absl::string_view())].has_value());
+  }
+}
+
+TEST_F(FlatBuffersTest, IndexedObjectVectorFieldDefaults) {
+  const CelMap& value = loadJson(R"({
+                                    r_indexed: [
+                                    {
+                                      f_string: "",
+                                      f_int: 16
+                                    }
+                                    ]
+                                    })");
+  auto f = value[CelValue::CreateStringView(kIndexedField)];
+  EXPECT_TRUE(f.has_value());
+  EXPECT_TRUE(f.value().IsMap());
+  const CelMap& m = *f.value().MapOrDie();
+  EXPECT_EQ(1, m.size());
+  const CelList& l = *m.ListKeys();
+  EXPECT_EQ(1, l.size());
+  EXPECT_TRUE(l[0].IsString());
+  EXPECT_EQ("", l[0].StringOrDie().value());
+  auto v = m[CelValue::CreateStringView(absl::string_view())];
+  EXPECT_TRUE(v.has_value());
+}
+
+}  // namespace
+
+}  // namespace runtime
+}  // namespace expr
+}  // namespace api
+}  // namespace google

--- a/tools/testdata/flatbuffers.fbs
+++ b/tools/testdata/flatbuffers.fbs
@@ -1,0 +1,44 @@
+namespace google.api.expr;
+
+table Entry {
+  f_string:string;
+  f_int:int;
+}
+
+table IndexedEntry {
+  f_string:string (key);
+  f_int:int;
+}
+
+table TestBuffer {
+  f_byte:byte;
+  f_ubyte:ubyte;
+  f_short:short = 150;
+  f_ushort:ushort;
+  f_int:int;
+  f_uint:uint;
+  f_long:long;
+  f_ulong:ulong;
+  f_float:float;
+  f_double:double;
+  f_bool:bool = true;
+  f_string:string;
+  f_obj:Entry;
+
+  r_byte:[byte];
+  r_ubyte:[ubyte];
+  r_short:[short];
+  r_ushort:[ushort];
+  r_int:[int];
+  r_uint:[uint];
+  r_long:[long];
+  r_ulong:[ulong];
+  r_float:[float];
+  r_double:[double];
+  r_bool:[bool];
+  r_string:[string];
+  r_obj:[Entry];
+  r_indexed:[IndexedEntry];
+}
+
+root_type TestBuffer;


### PR DESCRIPTION
```
306225043 by kuat <kuat@google.com>:

BEGIN_PUBLIC
Export cel/cpp/tools.
END_PUBLIC

--
305962063 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Move CelValueToValue() function from Explainer to utility class
END_PUBLIC
--
305731098 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Add btree set implementation for unknown function result sets. Improves performance for large numbers of unknown function results.
END_PUBLIC
```

PiperOrigin-RevId: 306225043