### PR TITLE
Export of internal changes

### DIFF
--- a/eval/public/activation.h
+++ b/eval/public/activation.h
@@ -39,15 +39,20 @@ class BaseActivation {
                                              google::protobuf::Arena*) const = 0;
 
   // Check whether a select path is unknown.
-  virtual bool IsPathUnknown(absl::string_view) const = 0;
+  virtual bool IsPathUnknown(absl::string_view) const { return false; }
 
   // Return FieldMask defining the list of unknown paths.
-  virtual const google::protobuf::FieldMask unknown_paths() const = 0;
+  virtual const google::protobuf::FieldMask& unknown_paths() const {
+    return google::protobuf::FieldMask::default_instance();
+  }
 
   // Return the collection of attribute patterns that determine "unknown"
   // values.
   virtual const std::vector<CelAttributePattern>& unknown_attribute_patterns()
-      const = 0;
+      const {
+    static const std::vector<CelAttributePattern> empty;
+    return empty;
+  }
 
   virtual ~BaseActivation() {}
 };
@@ -108,7 +113,7 @@ class Activation : public BaseActivation {
   }
 
   // Return FieldMask defining the list of unknown paths.
-  const google::protobuf::FieldMask unknown_paths() const override {
+  const google::protobuf::FieldMask& unknown_paths() const override {
     return unknown_paths_;
   }
 

--- a/eval/public/activation_test.cc
+++ b/eval/public/activation_test.cc
@@ -13,7 +13,6 @@ namespace runtime {
 namespace {
 
 using ::google::protobuf::Arena;
-using testing::_;
 using testing::ElementsAre;
 using testing::Eq;
 using testing::HasSubstr;

--- a/parser/BUILD
+++ b/parser/BUILD
@@ -26,8 +26,8 @@ cc_library(
     deps = [
         ":cel_cc_parser",
         ":macro",
+        ":source_factory",
         ":visitor",
-        "//base:status_macros",
         "//base:statusor",
         "@antlr4_runtimes//:cpp",
         "@com_google_absl//absl/types:optional",
@@ -75,7 +75,6 @@ cc_library(
         ":source_factory",
         "//common:escaping",
         "//common:operators",
-        "@antlr4_runtimes//:cpp",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
@@ -99,6 +98,7 @@ cc_library(
     ],
     deps = [
         ":cel_cc_parser",
+        "//base",
         "//common:operators",
         "@antlr4_runtimes//:cpp",
         "@com_google_absl//absl/memory",
@@ -115,6 +115,7 @@ cc_test(
     copts = ["-std=c++14"],
     deps = [
         ":parser",
+        ":source_factory",
         "//common:escaping",
         "@com_github_google_googletest//:gtest_main",
         "@com_google_absl//absl/memory",

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -4,12 +4,36 @@
 #include "google/api/expr/v1alpha1/syntax.pb.h"
 #include "absl/types/optional.h"
 #include "parser/macro.h"
+#include "parser/source_factory.h"
 #include "base/statusor.h"
 
 namespace google {
 namespace api {
 namespace expr {
 namespace parser {
+
+class VerboseParsedExpr {
+ public:
+  VerboseParsedExpr(const google::api::expr::v1alpha1::ParsedExpr& parsed_expr,
+                    const EnrichedSourceInfo& enriched_source_info)
+      : parsed_expr_(parsed_expr),
+        enriched_source_info_(enriched_source_info) {}
+
+  const google::api::expr::v1alpha1::ParsedExpr& parsed_expr() const {
+    return parsed_expr_;
+  }
+  const EnrichedSourceInfo enriched_source_info() const {
+    return enriched_source_info_;
+  }
+
+ private:
+  google::api::expr::v1alpha1::ParsedExpr parsed_expr_;
+  EnrichedSourceInfo enriched_source_info_;
+};
+
+cel_base::StatusOr<VerboseParsedExpr> EnrichedParse(
+    const std::string& expression, const std::vector<Macro>& macros,
+    const std::string& description = "<input>");
 
 cel_base::StatusOr<google::api::expr::v1alpha1::ParsedExpr> Parse(
     const std::string& expression, const std::string& description = "<input>");

--- a/parser/source_factory.h
+++ b/parser/source_factory.h
@@ -2,6 +2,7 @@
 #define THIRD_PARTY_CEL_CPP_PARSER_SOURCE_FACTORY_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "google/api/expr/v1alpha1/syntax.pb.h"
@@ -15,15 +16,28 @@ namespace parser {
 
 using google::api::expr::v1alpha1::Expr;
 
+class EnrichedSourceInfo {
+ public:
+  EnrichedSourceInfo(const std::vector<std::pair<int64_t, int32_t>>& offset_ends)
+      : offset_ends_(offset_ends) {}
+
+  const std::vector<std::pair<int64_t, int32_t>>& offset_ends() const {
+    return offset_ends_;
+  }
+
+ private:
+  std::vector<std::pair<int64_t, int32_t>> offset_ends_;
+};
+
 // Provide tools to generate expressions during parsing.
 // Keeps track of ID and source location information.
 // Shares functionality with //third_party/cel/go/parser/helper.go
 class SourceFactory {
  public:
   struct SourceLocation {
-    SourceLocation(int32_t line, int32_t col,
+    SourceLocation(int32_t line, int32_t col, int32_t offset_end,
                    const std::vector<int32_t>& line_offsets)
-        : line(line), col(col) {
+        : line(line), col(col), offset_end(offset_end) {
       if (line == 1) {
         offset = col;
       } else if (line > 1) {
@@ -34,6 +48,7 @@ class SourceFactory {
     }
     int32_t line;
     int32_t col;
+    int32_t offset_end;
     int32_t offset;
   };
 
@@ -118,7 +133,7 @@ class SourceFactory {
 
   bool isReserved(const std::string& ident_name);
   google::api::expr::v1alpha1::SourceInfo sourceInfo() const;
-
+  EnrichedSourceInfo enrichedSourceInfo() const;
   const std::vector<int32_t>& line_offsets() const;
   const std::vector<Error>& errors() const { return errors_; }
 

--- a/parser/visitor.cc
+++ b/parser/visitor.cc
@@ -422,6 +422,10 @@ google::api::expr::v1alpha1::SourceInfo ParserVisitor::sourceInfo() const {
   return sf_->sourceInfo();
 }
 
+EnrichedSourceInfo ParserVisitor::enrichedSourceInfo() const {
+  return sf_->enrichedSourceInfo();
+}
+
 void ParserVisitor::syntaxError(antlr4::Recognizer* recognizer,
                                 antlr4::Token* offending_symbol, size_t line,
                                 size_t col, const std::string& msg,

--- a/parser/visitor.h
+++ b/parser/visitor.h
@@ -5,6 +5,7 @@
 #include "absl/types/optional.h"
 #include "parser/cel_grammar.inc/cel_grammar/CelBaseVisitor.h"
 #include "parser/macro.h"
+#include "parser/source_factory.h"
 
 namespace google {
 namespace api {
@@ -76,6 +77,7 @@ class ParserVisitor : public ::cel_grammar::CelBaseVisitor,
       ::cel_grammar::CelParser::BoolFalseContext* ctx) override;
   antlrcpp::Any visitNull(::cel_grammar::CelParser::NullContext* ctx) override;
   google::api::expr::v1alpha1::SourceInfo sourceInfo() const;
+  EnrichedSourceInfo enrichedSourceInfo() const;
   void syntaxError(antlr4::Recognizer* recognizer,
                    antlr4::Token* offending_symbol, size_t line, size_t col,
                    const std::string& msg, std::exception_ptr e) override;


### PR DESCRIPTION
```
--
306564608 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Add EnrichedParse function to return enriched response with token end indexes.
END_PUBLIC
--
306523921 by kuat <kuat@google.com>:

BEGIN_PUBLIC
refactor: provide default implementations for BaseActivation.
refactor: return FieldMask by reference to avoid a protobuf copy.
END_PUBLIC
--
306335623 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Move explainer transform utility class to public path
END_PUBLIC
```
PiperOrigin-RevId: 306564608