### PR TITLE
Export of internal changes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,9 +126,9 @@ antlr_dependencies(472)
 
 http_archive(
     name = "antlr4_runtimes",
-    sha256 = "4d0714f441333a63e50031c9e8e4890c78f3d21e053d46416949803e122a6574",
-    strip_prefix = "antlr4-4.7.1",
-    urls = ["https://github.com/antlr/antlr4/archive/4.7.1.tar.gz"],
+    sha256 = "46f5e1af5f4bd28ade55cb632f9a069656b31fc8c2408f9aa045f9b5f5caad64",
+    strip_prefix = "antlr4-4.7.2",
+    urls = ["https://github.com/antlr/antlr4/archive/4.7.2.tar.gz"],
     build_file_content = """
 package(default_visibility = ["//visibility:public"])
 cc_library(

--- a/bazel/antlr.bzl
+++ b/bazel/antlr.bzl
@@ -42,4 +42,5 @@ def antlr_cc_library(name, src, listener = False, visitor = True):
         toolchains = [":" + generated],
         # ANTLR runtime does not build with dynamic linking
         linkstatic = True,
+        alwayslink = 1,
     )

--- a/eval/compiler/flat_expr_builder_test.cc
+++ b/eval/compiler/flat_expr_builder_test.cc
@@ -143,7 +143,7 @@ TEST(FlatExprBuilderTest, DelayedFunctionResolutionErrors) {
 
   ASSERT_THAT(warnings, testing::SizeIs(1));
   EXPECT_EQ(warnings[0].code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_THAT(warnings[0].message(),
+  EXPECT_THAT(std::string(warnings[0].message()),
               testing::HasSubstr("No overloads provided"));
 }
 

--- a/eval/eval/BUILD
+++ b/eval/eval/BUILD
@@ -672,31 +672,3 @@ cc_test(
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
     ],
 )
-
-cc_library(
-    name = "set_util",
-    srcs = ["set_util.cc"],
-    hdrs = ["set_util.h"],
-    copts = ["-std=c++14"],
-    deps = ["//eval/public:cel_value"],
-)
-
-cc_test(
-    name = "set_util_test",
-    size = "small",
-    srcs = [
-        "set_util_test.cc",
-    ],
-    copts = ["-std=c++14"],
-    deps = [
-        ":container_backed_list_impl",
-        ":container_backed_map_impl",
-        ":set_util",
-        "//eval/public:cel_value",
-        "//eval/public:unknown_set",
-        "@com_github_google_googletest//:gtest_main",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/time",
-        "@com_google_protobuf//:protobuf",
-    ],
-)

--- a/eval/eval/function_step.cc
+++ b/eval/eval/function_step.cc
@@ -47,7 +47,7 @@ bool ShouldAcceptOverload(const CelFunction* function,
   if (function == nullptr) {
     return false;
   }
-  for (int i = 0; i < arguments.size(); i++) {
+  for (size_t i = 0; i < arguments.size(); i++) {
     if (arguments[i].IsUnknownSet() || arguments[i].IsError()) {
       return IsNonStrict(function->descriptor().name());
     }
@@ -65,7 +65,7 @@ std::vector<CelValue> CheckForPartialUnknowns(
     absl::Span<const AttributeTrail> attrs) {
   std::vector<CelValue> result;
   result.reserve(args.size());
-  for (int i = 0; i < args.size(); i++) {
+  for (size_t i = 0; i < args.size(); i++) {
     auto attr_set = frame->unknowns_utility().CheckForUnknowns(
         attrs.subspan(i, 1), /*use_partial=*/true);
     if (!attr_set.attributes().empty()) {

--- a/eval/eval/function_step_test.cc
+++ b/eval/eval/function_step_test.cc
@@ -540,6 +540,7 @@ std::string TestNameFn(testing::TestParamInfo<UnknownProcessingOptions> opt) {
     case UnknownProcessingOptions::kAttributeAndFunction:
       return "attribute_and_function";
   }
+  return "";
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/eval/public/BUILD
+++ b/eval/public/BUILD
@@ -573,7 +573,7 @@ cc_library(
         ":cel_function",
         ":cel_options",
         ":cel_value",
-        "//eval/eval:set_util",
+        ":set_util",
         "@com_google_absl//absl/container:btree",
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
     ],
@@ -620,6 +620,34 @@ cc_test(
         ":unknown_set",
         "@com_github_google_googletest//:gtest_main",
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_library(
+    name = "set_util",
+    srcs = ["set_util.cc"],
+    hdrs = ["set_util.h"],
+    copts = ["-std=c++14"],
+    deps = ["//eval/public:cel_value"],
+)
+
+cc_test(
+    name = "set_util_test",
+    size = "small",
+    srcs = [
+        "set_util_test.cc",
+    ],
+    copts = ["-std=c++14"],
+    deps = [
+        ":cel_value",
+        ":set_util",
+        ":unknown_set",
+        "//eval/eval:container_backed_list_impl",
+        "//eval/eval:container_backed_map_impl",
+        "@com_github_google_googletest//:gtest_main",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/time",
         "@com_google_protobuf//:protobuf",
     ],
 )

--- a/eval/public/activation.h
+++ b/eval/public/activation.h
@@ -39,15 +39,20 @@ class BaseActivation {
                                              google::protobuf::Arena*) const = 0;
 
   // Check whether a select path is unknown.
-  virtual bool IsPathUnknown(absl::string_view) const = 0;
+  virtual bool IsPathUnknown(absl::string_view) const { return false; }
 
   // Return FieldMask defining the list of unknown paths.
-  virtual const google::protobuf::FieldMask unknown_paths() const = 0;
+  virtual const google::protobuf::FieldMask& unknown_paths() const {
+    return google::protobuf::FieldMask::default_instance();
+  }
 
   // Return the collection of attribute patterns that determine "unknown"
   // values.
   virtual const std::vector<CelAttributePattern>& unknown_attribute_patterns()
-      const = 0;
+      const {
+    static const std::vector<CelAttributePattern> empty;
+    return empty;
+  }
 
   virtual ~BaseActivation() {}
 };
@@ -108,7 +113,7 @@ class Activation : public BaseActivation {
   }
 
   // Return FieldMask defining the list of unknown paths.
-  const google::protobuf::FieldMask unknown_paths() const override {
+  const google::protobuf::FieldMask& unknown_paths() const override {
     return unknown_paths_;
   }
 

--- a/eval/public/activation_test.cc
+++ b/eval/public/activation_test.cc
@@ -13,7 +13,6 @@ namespace runtime {
 namespace {
 
 using ::google::protobuf::Arena;
-using testing::_;
 using testing::ElementsAre;
 using testing::Eq;
 using testing::HasSubstr;

--- a/eval/public/ast_traverse.cc
+++ b/eval/public/ast_traverse.cc
@@ -36,7 +36,7 @@ namespace {
 
 struct StackRecord {
  public:
-  static const int kNotCallArg = -1;
+  static constexpr int kNotCallArg = -1;
 
   StackRecord(const Expr *e, const SourceInfo *info)
       : expr(e),

--- a/eval/public/set_util.h
+++ b/eval/public/set_util.h
@@ -1,5 +1,5 @@
-#ifndef THIRD_PARTY_CEL_CPP_EVAL_EVAL_SET_UTIL_H_
-#define THIRD_PARTY_CEL_CPP_EVAL_EVAL_SET_UTIL_H_
+#ifndef THIRD_PARTY_CEL_CPP_EVAL_PUBLIC_SET_UTIL_H_
+#define THIRD_PARTY_CEL_CPP_EVAL_PUBLIC_SET_UTIL_H_
 
 #include "eval/public/cel_value.h"
 
@@ -25,14 +25,19 @@ namespace runtime {
 // Note that for For messages, errors, and unknown sets, this is a ptr
 // comparison.
 bool CelValueLessThan(CelValue lhs, CelValue rhs);
+bool CelValueEqual(CelValue lhs, CelValue rhs);
+bool CelValueGreaterThan(CelValue lhs, CelValue rhs);
+int CelValueCompare(CelValue lhs, CelValue rhs);
 
 // Convenience alias for using the CelValueLessThan function in sets providing
 // the stl interface.
 using CelValueLessThanComparator = decltype(&CelValueLessThan);
+using CelValueEqualComparator = decltype(&CelValueEqual);
+using CelValueGreaterThanComparator = decltype(&CelValueGreaterThan);
 
 }  // namespace runtime
 }  // namespace expr
 }  // namespace api
 }  // namespace google
 
-#endif  // THIRD_PARTY_CEL_CPP_EVAL_EVAL_SET_UTIL_H_
+#endif  // THIRD_PARTY_CEL_CPP_EVAL_PUBLIC_SET_UTIL_H_

--- a/eval/public/set_util_test.cc
+++ b/eval/public/set_util_test.cc
@@ -1,4 +1,4 @@
-#include "eval/eval/set_util.h"
+#include "eval/public/set_util.h"
 
 #include <cstddef>
 
@@ -85,8 +85,7 @@ TEST_P(TypeOrderingTest, TypeLessThan) {
   // Strict less than.
   EXPECT_EQ(CelValueLessThan(lhs, rhs), i_ < j_);
   // Equality.
-  EXPECT_EQ(!CelValueLessThan(lhs, rhs) && !CelValueLessThan(rhs, lhs),
-            i_ == j_);
+  EXPECT_EQ(CelValueEqual(lhs, rhs), i_ == j_);
 }
 
 std::string TypeOrderingTestName(
@@ -151,11 +150,10 @@ TEST_P(PrimitiveCmpTest, Basic) {
       EXPECT_TRUE(CelValueLessThan(lhs_, rhs_));
       break;
     case ExpectedCmp::kGt:
-      EXPECT_TRUE(CelValueLessThan(rhs_, lhs_));
+      EXPECT_TRUE(CelValueGreaterThan(lhs_, rhs_));
       break;
     case ExpectedCmp::kEq:
-      EXPECT_TRUE(!CelValueLessThan(lhs_, rhs_) &&
-                  !CelValueLessThan(rhs_, lhs_));
+      EXPECT_TRUE(CelValueEqual(lhs_, rhs_));
       break;
   }
 }
@@ -298,8 +296,8 @@ TEST(CelValueLessThan, CelListEqual) {
 
   EXPECT_FALSE(CelValueLessThan(CelValue::CreateList(&cel_list_1),
                                 CelValue::CreateList(&cel_list_2)));
-  EXPECT_FALSE(CelValueLessThan(CelValue::CreateList(&cel_list_2),
-                                CelValue::CreateList(&cel_list_1)));
+  EXPECT_TRUE(CelValueEqual(CelValue::CreateList(&cel_list_2),
+                            CelValue::CreateList(&cel_list_1)));
 }
 
 TEST(CelValueLessThan, CelListSupportProtoListCompatible) {
@@ -388,8 +386,8 @@ TEST(CelValueLessThan, CelMapEqual) {
 
   EXPECT_FALSE(CelValueLessThan(CelValue::CreateMap(cel_map_1.get()),
                                 CelValue::CreateMap(cel_map_2.get())));
-  EXPECT_FALSE(CelValueLessThan(CelValue::CreateMap(cel_map_2.get()),
-                                CelValue::CreateMap(cel_map_1.get())));
+  EXPECT_TRUE(CelValueEqual(CelValue::CreateMap(cel_map_2.get()),
+                            CelValue::CreateMap(cel_map_1.get())));
 }
 
 TEST(CelValueLessThan, CelMapSupportProtoMapCompatible) {
@@ -422,7 +420,7 @@ TEST(CelValueLessThan, CelMapSupportProtoMapCompatible) {
   CelValue cel_map = CelValue::CreateMap(backing_map.get());
 
   EXPECT_TRUE(!CelValueLessThan(cel_map, proto_struct) &&
-              !CelValueLessThan(proto_struct, cel_map));
+              !CelValueGreaterThan(cel_map, proto_struct));
 }
 
 TEST(CelValueLessThan, NestedMap) {

--- a/eval/public/unknown_function_result_set.cc
+++ b/eval/public/unknown_function_result_set.cc
@@ -3,10 +3,10 @@
 #include <type_traits>
 
 #include "absl/container/btree_set.h"
-#include "eval/eval/set_util.h"
 #include "eval/public/cel_function.h"
 #include "eval/public/cel_options.h"
 #include "eval/public/cel_value.h"
+#include "eval/public/set_util.h"
 
 namespace google {
 namespace api {

--- a/internal/value_internal_test.cc
+++ b/internal/value_internal_test.cc
@@ -71,9 +71,9 @@ TEST_F(ValueAdapterTest, NullPtr) {
 
 TEST_F(ValueAdapterTest, RefPtr) {
   // Smart pointer is dereferenced.
-  auto ptr = RefPtrHolder<RefOnlyType>();
+  auto ptr = RefPtrHolder<RefOnlyType>(new RefOnlyType());
   TestAdapter<RefOnlyType&>(ptr, *ptr);
-  auto cptr = RefPtrHolder<const RefOnlyType>();
+  auto cptr = RefPtrHolder<const RefOnlyType>(new RefOnlyType());
   TestAdapter<const RefOnlyType&>(cptr, *cptr);
 }
 

--- a/parser/BUILD
+++ b/parser/BUILD
@@ -26,8 +26,8 @@ cc_library(
     deps = [
         ":cel_cc_parser",
         ":macro",
+        ":source_factory",
         ":visitor",
-        "//base:status_macros",
         "//base:statusor",
         "@antlr4_runtimes//:cpp",
         "@com_google_absl//absl/types:optional",
@@ -75,7 +75,6 @@ cc_library(
         ":source_factory",
         "//common:escaping",
         "//common:operators",
-        "@antlr4_runtimes//:cpp",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
@@ -115,6 +114,7 @@ cc_test(
     copts = ["-std=c++14"],
     deps = [
         ":parser",
+        ":source_factory",
         "//common:escaping",
         "@com_github_google_googletest//:gtest_main",
         "@com_google_absl//absl/memory",

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -4,12 +4,36 @@
 #include "google/api/expr/v1alpha1/syntax.pb.h"
 #include "absl/types/optional.h"
 #include "parser/macro.h"
+#include "parser/source_factory.h"
 #include "base/statusor.h"
 
 namespace google {
 namespace api {
 namespace expr {
 namespace parser {
+
+class VerboseParsedExpr {
+ public:
+  VerboseParsedExpr(const google::api::expr::v1alpha1::ParsedExpr& parsed_expr,
+                    const EnrichedSourceInfo& enriched_source_info)
+      : parsed_expr_(parsed_expr),
+        enriched_source_info_(enriched_source_info) {}
+
+  const google::api::expr::v1alpha1::ParsedExpr& parsed_expr() const {
+    return parsed_expr_;
+  }
+  const EnrichedSourceInfo& enriched_source_info() const {
+    return enriched_source_info_;
+  }
+
+ private:
+  google::api::expr::v1alpha1::ParsedExpr parsed_expr_;
+  EnrichedSourceInfo enriched_source_info_;
+};
+
+cel_base::StatusOr<VerboseParsedExpr> EnrichedParse(
+    const std::string& expression, const std::vector<Macro>& macros,
+    const std::string& description = "<input>");
 
 cel_base::StatusOr<google::api::expr::v1alpha1::ParsedExpr> Parse(
     const std::string& expression, const std::string& description = "<input>");

--- a/parser/parser_test.cc
+++ b/parser/parser_test.cc
@@ -10,6 +10,7 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
 #include "common/escaping.h"
+#include "parser/source_factory.h"
 
 namespace google {
 namespace api {
@@ -23,8 +24,9 @@ using testing::Not;
 
 struct TestInfo {
   TestInfo(const std::string& I, const std::string& P,
-           const std::string& E = "", const std::string& L = "")
-      : I(I), P(P), E(E), L(L) {}
+           const std::string& E = "", const std::string& L = "",
+           const std::string& R = "")
+      : I(I), P(P), E(E), L(L), R(R) {}
 
   // I contains the input expression to be parsed.
   std::string I;
@@ -38,6 +40,9 @@ struct TestInfo {
 
   // L contains the expected source adorned debug output of the expression tree.
   std::string L;
+
+  // R contains the expected enriched source info output of the expression tree.
+  std::string R;
 };
 
 std::vector<TestInfo> test_cases = {
@@ -344,6 +349,18 @@ std::vector<TestInfo> test_cases = {
         "a^#1[1,0]#.b(\n"
         "  c^#3[1,4]#\n"
         ")^#2[1,3]#",
+        "[1,0,0]^#[2,3,3]^#[3,4,4]",
+    },
+    {
+        "aaa.bbb(ccc)",
+        "aaa^#1:Expr.Ident#.bbb(\n"
+        "  ccc^#3:Expr.Ident#\n"
+        ")^#2:Expr.Call#",
+        /* E */ "",
+        "aaa^#1[1,0]#.bbb(\n"
+        "  ccc^#3[1,8]#\n"
+        ")^#2[1,7]#",
+        "[1,0,2]^#[2,7,7]^#[3,8,10]",
     },
 
     // Parse error tests
@@ -377,6 +394,7 @@ std::vector<TestInfo> test_cases = {
         "m^#2:Expr.Ident#.f~test-only~^#4:Expr.Select#",
         "",
         "m^#2[1,4]#.f~test-only~^#4[1,3]#",
+        "[1,3,3]^#[2,4,4]^#[3,5,5]^#[4,3,3]",
     },
     {"m.exists_one(v, f)",
      "__comprehension__(\n"
@@ -1129,23 +1147,22 @@ class DebugWriter {
   int indent_;
 };
 
+std::string ConvertEnrichedSourceInfoToString(
+    const EnrichedSourceInfo& enriched_source_info) {
+  std::vector<std::string> offsets;
+  for (const auto& offset : enriched_source_info.offsets()) {
+    offsets.push_back(absl::StrFormat(
+        "[%d,%d,%d]", offset.first, offset.second.first, offset.second.second));
+  }
+  return absl::StrJoin(offsets, "^#");
+}
+
 class ExpressionTest : public testing::TestWithParam<TestInfo> {};
 
 TEST_P(ExpressionTest, Parse) {
   const TestInfo& test_info = GetParam();
-  /*
-  ::testing::internal::ColoredPrintf(::testing::internal::COLOR_GREEN,
-                                     "[          ]");
-  ::testing::internal::ColoredPrintf(::testing::internal::COLOR_DEFAULT,
-                                     " Expression: ");
-  ::testing::internal::ColoredPrintf(::testing::internal::COLOR_YELLOW, "%s",
-                                     test_info.I.c_str());
-  ::testing::internal::ColoredPrintf(
-      ::testing::internal::COLOR_DEFAULT, "%s\n",
-      !test_info.E.empty() ? " (error expected)" : "");
-  */
 
-  auto result = Parse(test_info.I);
+  auto result = EnrichedParse(test_info.I, Macro::AllMacros());
   if (test_info.E.empty()) {
     EXPECT_TRUE(result.ok());
   } else {
@@ -1156,15 +1173,24 @@ TEST_P(ExpressionTest, Parse) {
   if (!test_info.P.empty()) {
     KindAndIdAdorner kind_and_id_adorner;
     DebugWriter w(kind_and_id_adorner);
-    std::string adorned_string = w.toAdornedDebugString(result.value());
+    std::string adorned_string =
+        w.toAdornedDebugString(result.value().parsed_expr());
     EXPECT_EQ(test_info.P, adorned_string);
   }
 
   if (!test_info.L.empty()) {
-    LocationAdorner location_adorner(result.value().source_info());
+    LocationAdorner location_adorner(
+        result.value().parsed_expr().source_info());
     DebugWriter w(location_adorner);
-    std::string adorned_string = w.toAdornedDebugString(result.value());
+    std::string adorned_string =
+        w.toAdornedDebugString(result.value().parsed_expr());
     EXPECT_EQ(test_info.L, adorned_string);
+  }
+
+  if (!test_info.R.empty()) {
+    EXPECT_EQ(ConvertEnrichedSourceInfoToString(
+                  result.value().enriched_source_info()),
+              test_info.R);
   }
 }
 

--- a/parser/source_factory.h
+++ b/parser/source_factory.h
@@ -2,6 +2,7 @@
 #define THIRD_PARTY_CEL_CPP_PARSER_SOURCE_FACTORY_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "google/api/expr/v1alpha1/syntax.pb.h"
@@ -15,15 +16,29 @@ namespace parser {
 
 using google::api::expr::v1alpha1::Expr;
 
+class EnrichedSourceInfo {
+ public:
+  EnrichedSourceInfo(const std::map<int64_t, std::pair<int32_t, int32_t>>& offsets)
+      : offsets_(offsets) {}
+
+  const std::map<int64_t, std::pair<int32_t, int32_t>>& offsets() const {
+    return offsets_;
+  }
+
+ private:
+  // A map between node_id and pair of start position and end position
+  std::map<int64_t, std::pair<int32_t, int32_t>> offsets_;
+};
+
 // Provide tools to generate expressions during parsing.
 // Keeps track of ID and source location information.
 // Shares functionality with //third_party/cel/go/parser/helper.go
 class SourceFactory {
  public:
   struct SourceLocation {
-    SourceLocation(int32_t line, int32_t col,
+    SourceLocation(int32_t line, int32_t col, int32_t offset_end,
                    const std::vector<int32_t>& line_offsets)
-        : line(line), col(col) {
+        : line(line), col(col), offset_end(offset_end) {
       if (line == 1) {
         offset = col;
       } else if (line > 1) {
@@ -34,6 +49,7 @@ class SourceFactory {
     }
     int32_t line;
     int32_t col;
+    int32_t offset_end;
     int32_t offset;
   };
 
@@ -118,7 +134,7 @@ class SourceFactory {
 
   bool isReserved(const std::string& ident_name);
   google::api::expr::v1alpha1::SourceInfo sourceInfo() const;
-
+  EnrichedSourceInfo enrichedSourceInfo() const;
   const std::vector<int32_t>& line_offsets() const;
   const std::vector<Error>& errors() const { return errors_; }
 

--- a/parser/visitor.cc
+++ b/parser/visitor.cc
@@ -336,6 +336,29 @@ antlrcpp::Any ParserVisitor::visitCreateStruct(
   return sf_->newMap(struct_id, entries);
 }
 
+antlrcpp::Any ParserVisitor::visitConstantLiteral(
+    CelParser::ConstantLiteralContext* clctx) {
+  CelParser::LiteralContext* literal = clctx->literal();
+  if (auto* ctx = tree_as<CelParser::IntContext>(literal)) {
+    return visitInt(ctx);
+  } else if (auto* ctx = tree_as<CelParser::UintContext>(literal)) {
+    return visitUint(ctx);
+  } else if (auto* ctx = tree_as<CelParser::DoubleContext>(literal)) {
+    return visitDouble(ctx);
+  } else if (auto* ctx = tree_as<CelParser::StringContext>(literal)) {
+    return visitString(ctx);
+  } else if (auto* ctx = tree_as<CelParser::BytesContext>(literal)) {
+    return visitBytes(ctx);
+  } else if (auto* ctx = tree_as<CelParser::BoolFalseContext>(literal)) {
+    return visitBoolFalse(ctx);
+  } else if (auto* ctx = tree_as<CelParser::BoolTrueContext>(literal)) {
+    return visitBoolTrue(ctx);
+  } else if (auto* ctx = tree_as<CelParser::NullContext>(literal)) {
+    return visitNull(ctx);
+  }
+  return sf_->reportError(clctx, "invalid constant literal expression");
+}
+
 antlrcpp::Any ParserVisitor::visitMapInitializerList(
     CelParser::MapInitializerListContext* ctx) {
   std::vector<Expr::CreateStruct::Entry> res;
@@ -420,6 +443,10 @@ antlrcpp::Any ParserVisitor::visitNull(CelParser::NullContext* ctx) {
 
 google::api::expr::v1alpha1::SourceInfo ParserVisitor::sourceInfo() const {
   return sf_->sourceInfo();
+}
+
+EnrichedSourceInfo ParserVisitor::enrichedSourceInfo() const {
+  return sf_->enrichedSourceInfo();
 }
 
 void ParserVisitor::syntaxError(antlr4::Recognizer* recognizer,

--- a/parser/visitor.h
+++ b/parser/visitor.h
@@ -5,6 +5,7 @@
 #include "absl/types/optional.h"
 #include "parser/cel_grammar.inc/cel_grammar/CelBaseVisitor.h"
 #include "parser/macro.h"
+#include "parser/source_factory.h"
 
 namespace google {
 namespace api {
@@ -55,6 +56,8 @@ class ParserVisitor : public ::cel_grammar::CelBaseVisitor,
       ::cel_grammar::CelParser::ExprListContext* ctx);
   antlrcpp::Any visitCreateStruct(
       ::cel_grammar::CelParser::CreateStructContext* ctx) override;
+  antlrcpp::Any visitConstantLiteral(
+      ::cel_grammar::CelParser::ConstantLiteralContext* ctx) override;
   antlrcpp::Any visitPrimaryExpr(
       ::cel_grammar::CelParser::PrimaryExprContext* ctx) override;
   antlrcpp::Any visitMemberExpr(
@@ -76,6 +79,7 @@ class ParserVisitor : public ::cel_grammar::CelBaseVisitor,
       ::cel_grammar::CelParser::BoolFalseContext* ctx) override;
   antlrcpp::Any visitNull(::cel_grammar::CelParser::NullContext* ctx) override;
   google::api::expr::v1alpha1::SourceInfo sourceInfo() const;
+  EnrichedSourceInfo enrichedSourceInfo() const;
   void syntaxError(antlr4::Recognizer* recognizer,
                    antlr4::Token* offending_symbol, size_t line, size_t col,
                    const std::string& msg, std::exception_ptr e) override;


### PR DESCRIPTION
Export of internal changes

--
310915802 by tswadell <tswadell@google.com>:
Upgrade the ANTLR runtime to 4.7.2
--
310910752 by CEL Dev Team <cel-dev@google.com>:
Add missing override for CEL parser visitor visitConstantLiteral()

The default implementation is incompatible with Antlr 4.7.2. An upgrade is
desirable to benefit from thread-safety improvements.
--
309264125 by CEL Dev Team <cel-dev@google.com>:

Internal change
--
309098060 by CEL Dev Team <cel-dev@google.com>:
Internal Change
--
309036708 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Moves set_util from cel/cpp/eval/eval to cel/cpp/eval/public
END_PUBLIC
--
308324817 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Update EnrichSourceInfo to contain a map of node_id with positions
END_PUBLIC
--
308317802 by CEL Dev Team <cel-dev@google.com>:

LSC: Fix incorrect string escapes in Copybara config files

For example, the regex "\w" is invalid. It should be either: r"\w" or "\\w"

This CL does not change behavior: Copybara currently treats invalid
escapes (like "\w") equivalently to the corrected versions (like "\\w").

Copybara is going to enable strict Starlark validation. As part
of this change we are going to enable restrictStringEscapes. This flag
prevents users from using incorrect escapes.

This was done by running buildifier copy.bara.sky

More information: go/copybara-strict-string-escapes

BEGIN_PUBLIC
Internal change
END_PUBLIC

Tested:
    TAP --sample ran all affected tests and none failed
    http://test/OCL:308094157:BASE:308146641:1587694686416:2641e69f
--
308129984 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Extends the CelValueLessThan Visitor implementation to handle less than, deep equality and greater than in a single pass.
Adds functions to check for deep equality and greater than of two CelValues using the extended Visitor.
END_PUBLIC
--
307113050 by CEL Dev Team <cel-dev@google.com>:

LSC: Mark static const class/struct members as constexpr. This change fixes declarations that have initial values but are technically not definitions by marking them constexpr (which counts as a definition). This enables, among other things, the modified constants to be passed into functions and function templates that accept arguments by reference. Without this change, such functions would cause linker errors.

This change was approved as part of go/static-const-lsc.

Tested:
    TAP train for global presubmit queue
    http://test/OCL:306269815:BASE:306377582:1586865021582:ea5fa059
--
307074803 by tswadell <tswadell@google.com>:

Delete the legacy conformance directory under google/api/expr/conformance

BEGIN_PUBLIC
Build visibility change
END_PUBLIC
--
306984679 by kuat <kuat@google.com>:

BEGIN_PUBLIC
Internal change.
END_PUBLIC

Remove //base dependency.
Fix gcc compiler warnings.
--
306926648 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Bugfix: return reference of EnrichedSourceInfo in getter.
END_PUBLIC

- Make Parser visible to caa troubleshooter
--
306564608 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Add EnrichedParse function to return enriched response with token end indexes.
END_PUBLIC
--
306523921 by kuat <kuat@google.com>:

BEGIN_PUBLIC
refactor: provide default implementations for BaseActivation.
refactor: return FieldMask by reference to avoid a protobuf copy.
END_PUBLIC
--
306335623 by CEL Dev Team <cel-dev@google.com>:

BEGIN_PUBLIC
Move explainer transform utility class to public path
END_PUBLIC
