### PR TITLE
Subject: change made to an initialization of string_view with null pointer.

### DIFF
--- a/eval/public/cel_value.h
+++ b/eval/public/cel_value.h
@@ -47,7 +47,7 @@ class CelValue {
   template <int N>
   class StringHolderBase {
    public:
-    StringHolderBase() : value_({}) {}
+    StringHolderBase() : value_() {}
 
     StringHolderBase(const StringHolderBase &) = default;
     StringHolderBase &operator=(const StringHolderBase &) = default;


### PR DESCRIPTION
  https://github.com/google/cel-cpp/pull/45 this PR deals with the
  majority of changes needed for string_view() to work with C++17(std
  forbids an initialization with nullptrs). This PR fixes an instance where
  that has been left off.

Signed-off-by: Yifan Yang <needyyang@google.com>