### PR TITLE
Subject: initialization of std::string_view with null pointer

### DIFF
--- a/eval/public/cel_value.h
+++ b/eval/public/cel_value.h
@@ -47,7 +47,7 @@ class CelValue {
   template <int N>
   class StringHolderBase {
    public:
-    StringHolderBase() : value_({}) {}
+    StringHolderBase() : value_() {}
 
     StringHolderBase(const StringHolderBase &) = default;
     StringHolderBase &operator=(const StringHolderBase &) = default;


### PR DESCRIPTION
When switching to C++17, absl::string_view implicitly uses
std::string_view. Initialization of string_view with nullptr was
allowed in abseil implementation of string_view but the same is not
true in std. https://github.com/google/cel-cpp/pull/45 fixes majority
of these instances. But, in this instance, it has been left out.

Signed-off-by: Yifan Yang <needyyang@google.com>