### PR TITLE
c++17 build flag changes

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -13,7 +13,7 @@ cc_library(
         "statusor.h",
         "statusor_internals.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/meta:type_traits",
@@ -26,5 +26,5 @@ cc_library(
     hdrs = [
         "status_macros.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
 )

--- a/common/BUILD
+++ b/common/BUILD
@@ -12,7 +12,7 @@ cc_library(
     hdrs = [
         "macros.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [],
 )
 
@@ -21,7 +21,7 @@ cc_library(
     hdrs = [
         "id.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//internal:cel_printer",
         "//internal:handle",
@@ -35,7 +35,7 @@ cc_library(
     hdrs = [
         "type.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//internal:handle",
         "@com_google_absl//absl/memory",
@@ -51,7 +51,7 @@ cc_library(
     hdrs = [
         "enum.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":type",
         "//internal:cel_printer",
@@ -66,7 +66,7 @@ cc_library(
     hdrs = [
         "error.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//internal:cel_printer",
         "//internal:hash_util",
@@ -84,7 +84,7 @@ cc_library(
     hdrs = [
         "unknown.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":id",
         ":macros",
@@ -100,7 +100,7 @@ cc_library(
     hdrs = [
         "parent_ref.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//internal:ref_countable",
         "@com_google_absl//absl/types:optional",
@@ -115,7 +115,7 @@ cc_library(
     hdrs = [
         "custom_object.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":value",
     ],
@@ -129,7 +129,7 @@ cc_library(
     hdrs = [
         "operators.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
@@ -145,7 +145,7 @@ cc_library(
     hdrs = [
         "escaping.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
@@ -156,7 +156,7 @@ cc_library(
 cc_test(
     name = "escaping_test",
     srcs = ["escaping_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":escaping",
         "@com_github_google_googletest//:gtest_main",
@@ -171,7 +171,7 @@ cc_library(
     hdrs = [
         "value.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":enum",
         ":error",
@@ -202,7 +202,7 @@ cc_library(
 cc_test(
     name = "value_test",
     srcs = ["value_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":custom_object",
         ":value",
@@ -226,7 +226,7 @@ cc_library(
     hdrs = [
         "converters.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":parent_ref",
         ":value",
@@ -239,7 +239,7 @@ cc_library(
 cc_test(
     name = "converters_test",
     srcs = ["converters_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":converters",
         ":value",

--- a/conformance/BUILD
+++ b/conformance/BUILD
@@ -31,7 +31,7 @@ cc_binary(
     name = "server",
     testonly = 1,
     srcs = ["server.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//base:statusor",
         "//eval/eval:container_backed_list_impl",

--- a/eval/compiler/BUILD
+++ b/eval/compiler/BUILD
@@ -14,7 +14,7 @@ cc_library(
     hdrs = [
         "flat_expr_builder.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":constant_folding",
         "//base:status_macros",
@@ -45,7 +45,7 @@ cc_test(
     srcs = [
         "flat_expr_builder_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":flat_expr_builder",
         "//base:status_macros",
@@ -71,7 +71,7 @@ cc_test(
     srcs = [
         "flat_expr_builder_comprehensions_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":flat_expr_builder",
         "//base:status_macros",
@@ -100,7 +100,7 @@ cc_library(
     hdrs = [
         "constant_folding.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//eval/eval:const_value_step",
         "//eval/eval:container_backed_list_impl",
@@ -119,7 +119,7 @@ cc_test(
     srcs = [
         "constant_folding_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":constant_folding",
         "//base:status_macros",

--- a/eval/eval/BUILD
+++ b/eval/eval/BUILD
@@ -14,7 +14,7 @@ cc_library(
     hdrs = [
         "evaluator_core.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":attribute_trail",
         ":unknowns_utility",
@@ -37,7 +37,7 @@ cc_library(
     hdrs = [
         "expression_step_base.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         "//eval/public:activation",
@@ -57,7 +57,7 @@ cc_library(
     hdrs = [
         "const_value_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":expression_step_base",
@@ -78,7 +78,7 @@ cc_library(
     hdrs = [
         "container_access_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":expression_step_base",
@@ -99,7 +99,7 @@ cc_library(
     hdrs = [
         "ident_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":expression_step_base",
@@ -119,7 +119,7 @@ cc_library(
     hdrs = [
         "function_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":attribute_trail",
         ":evaluator_core",
@@ -149,7 +149,7 @@ cc_library(
     hdrs = [
         "field_access.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//eval/public:cel_value",
         "//internal:proto_util",
@@ -166,7 +166,7 @@ cc_library(
     hdrs = [
         "container_backed_list_impl.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//eval/public:cel_value",
         "@com_google_absl//absl/strings",
@@ -182,7 +182,7 @@ cc_library(
     hdrs = [
         "container_backed_map_impl.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//eval/public:cel_value",
         "@com_google_absl//absl/container:node_hash_map",
@@ -198,7 +198,7 @@ cc_library(
     hdrs = [
         "field_backed_list_impl.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":field_access",
         "//eval/public:cel_value",
@@ -214,7 +214,7 @@ cc_library(
     hdrs = [
         "field_backed_map_impl.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":field_access",
         "//eval/public:cel_value",
@@ -231,7 +231,7 @@ cc_library(
     hdrs = [
         "select_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":expression_step_base",
@@ -252,7 +252,7 @@ cc_library(
     hdrs = [
         "create_list_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":container_backed_list_impl",
         ":evaluator_core",
@@ -273,7 +273,7 @@ cc_library(
     hdrs = [
         "create_struct_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":container_backed_map_impl",
         ":evaluator_core",
@@ -294,7 +294,7 @@ cc_library(
     hdrs = [
         "jump_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":expression_step_base",
@@ -313,7 +313,7 @@ cc_library(
     hdrs = [
         "logic_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":expression_step_base",
@@ -334,7 +334,7 @@ cc_library(
     hdrs = [
         "comprehension_step.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":expression_step_base",
@@ -353,7 +353,7 @@ cc_test(
     srcs = [
         "evaluator_core_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         "//base:status_macros",
@@ -372,7 +372,7 @@ cc_test(
     srcs = [
         "const_value_step_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":const_value_step",
         ":evaluator_core",
@@ -388,7 +388,7 @@ cc_test(
     srcs = [
         "container_access_step_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":container_access_step",
         ":container_backed_list_impl",
@@ -409,7 +409,7 @@ cc_test(
     srcs = [
         "ident_step_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":ident_step",
@@ -425,7 +425,7 @@ cc_test(
     srcs = [
         "function_step_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":expression_build_warning",
@@ -451,7 +451,7 @@ cc_test(
     srcs = [
         "container_backed_map_impl_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":container_backed_map_impl",
         "//eval/public:cel_value",
@@ -466,7 +466,7 @@ cc_test(
     srcs = [
         "field_backed_list_impl_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":field_backed_list_impl",
@@ -482,7 +482,7 @@ cc_test(
     srcs = [
         "field_backed_map_impl_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":evaluator_core",
         ":field_backed_map_impl",
@@ -498,7 +498,7 @@ cc_test(
     srcs = [
         "logic_step_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":ident_step",
         ":logic_step",
@@ -515,7 +515,7 @@ cc_test(
     srcs = [
         "select_step_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":container_backed_map_impl",
         ":ident_step",
@@ -536,7 +536,7 @@ cc_test(
     srcs = [
         "create_list_step_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":const_value_step",
         ":create_list_step",
@@ -556,7 +556,7 @@ cc_test(
     srcs = [
         "create_struct_step_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":container_backed_list_impl",
         ":container_backed_map_impl",
@@ -579,7 +579,7 @@ cc_library(
     hdrs = [
         "expression_build_warning.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_google_absl//absl/status",
     ],
@@ -591,7 +591,7 @@ cc_test(
     srcs = [
         "expression_build_warning_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":expression_build_warning",
         "@com_github_google_googletest//:gtest_main",
@@ -603,7 +603,7 @@ cc_library(
     name = "attribute_trail",
     srcs = ["attribute_trail.cc"],
     hdrs = ["attribute_trail.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//base:statusor",
         "//eval/public:activation",
@@ -624,7 +624,7 @@ cc_test(
     srcs = [
         "attribute_trail_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":attribute_trail",
         "//eval/public:cel_attribute",
@@ -638,7 +638,7 @@ cc_library(
     name = "unknowns_utility",
     srcs = ["unknowns_utility.cc"],
     hdrs = ["unknowns_utility.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":attribute_trail",
         "//base:statusor",
@@ -661,7 +661,7 @@ cc_test(
     srcs = [
         "unknowns_utility_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":unknowns_utility",
         "//eval/public:cel_attribute",

--- a/eval/public/BUILD
+++ b/eval/public/BUILD
@@ -9,7 +9,7 @@ cc_library(
     hdrs = [
         "cel_value_internal.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_google_absl//absl/types:variant",
     ],
@@ -23,7 +23,7 @@ cc_library(
     hdrs = [
         "cel_value.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_value_internal",
         "//base:statusor",
@@ -44,7 +44,7 @@ cc_library(
     hdrs = [
         "cel_attribute.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_value",
         ":cel_value_internal",
@@ -61,7 +61,7 @@ cc_library(
     hdrs = [
         "cel_value_producer.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_value",
         "@com_google_absl//absl/strings",
@@ -75,7 +75,7 @@ cc_library(
     hdrs = [
         "unknown_attribute_set.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_attribute",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -90,7 +90,7 @@ cc_library(
     hdrs = [
         "activation.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_attribute",
         ":cel_function",
@@ -111,7 +111,7 @@ cc_library(
     hdrs = [
         "activation_bind_helper.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":activation",
         "//eval/eval:field_access",
@@ -129,7 +129,7 @@ cc_library(
     hdrs = [
         "cel_function.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_value",
         "@com_google_absl//absl/types:span",
@@ -144,7 +144,7 @@ cc_library(
     hdrs = [
         "cel_function_adapter.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_function",
         ":cel_function_registry",
@@ -163,7 +163,7 @@ cc_library(
     hdrs = [
         "cel_function_provider.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":activation",
         ":cel_function",
@@ -175,7 +175,7 @@ cc_library(
     hdrs = [
         "cel_builtins.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
     ],
 )
@@ -188,7 +188,7 @@ cc_library(
     hdrs = [
         "builtin_func_registrar.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_builtins",
         ":cel_function",
@@ -211,7 +211,7 @@ cc_library(
     hdrs = [
         "extension_func_registrar.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_function",
         ":cel_function_adapter",
@@ -227,7 +227,7 @@ cc_library(
     hdrs = [
         "cel_expression.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":activation",
         ":cel_function",
@@ -242,7 +242,7 @@ cc_library(
     name = "source_position",
     srcs = ["source_position.cc"],
     hdrs = ["source_position.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
         "@com_google_protobuf//:protobuf_lite",
@@ -254,7 +254,7 @@ cc_library(
     hdrs = [
         "ast_visitor.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":source_position",
         "@com_google_absl//absl/strings",
@@ -267,7 +267,7 @@ cc_library(
     hdrs = [
         "ast_visitor_base.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":ast_visitor",
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
@@ -282,7 +282,7 @@ cc_library(
     hdrs = [
         "ast_traverse.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":ast_visitor",
         ":source_position",
@@ -296,7 +296,7 @@ cc_library(
     hdrs = [
         "cel_options.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_google_protobuf//:protobuf",
     ],
@@ -310,7 +310,7 @@ cc_library(
     hdrs = [
         "cel_expr_builder_factory.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_expression",
         ":cel_options",
@@ -326,7 +326,7 @@ cc_library(
     hdrs = [
         "value_export_util.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_value",
         "@com_google_absl//absl/status",
@@ -339,7 +339,7 @@ cc_library(
     name = "cel_function_registry",
     srcs = ["cel_function_registry.cc"],
     hdrs = ["cel_function_registry.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_function",
         ":cel_function_provider",
@@ -356,7 +356,7 @@ cc_test(
     srcs = [
         "cel_value_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_value",
         ":unknown_attribute_set",
@@ -374,7 +374,7 @@ cc_test(
     srcs = [
         "cel_attribute_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_attribute",
         ":cel_value",
@@ -390,7 +390,7 @@ cc_test(
     srcs = [
         "activation_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":activation",
         ":cel_function",
@@ -404,7 +404,7 @@ cc_test(
     srcs = [
         "ast_traverse_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":ast_traverse",
         "@com_github_google_googletest//:gtest_main",
@@ -417,7 +417,7 @@ cc_test(
     srcs = [
         "activation_bind_helper_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":activation",
         ":activation_bind_helper",
@@ -434,7 +434,7 @@ cc_test(
     srcs = [
         "cel_function_provider_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_function",
         ":cel_function_provider",
@@ -448,7 +448,7 @@ cc_test(
     srcs = [
         "cel_function_registry_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_function",
         ":cel_function_provider",
@@ -464,7 +464,7 @@ cc_test(
     srcs = [
         "cel_function_adapter_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_function",
         ":cel_function_adapter",
@@ -480,7 +480,7 @@ cc_test(
     srcs = [
         "builtin_func_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":activation",
         ":builtin_func_registrar",
@@ -501,7 +501,7 @@ cc_test(
     srcs = [
         "extension_func_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":builtin_func_registrar",
         ":cel_function_registry",
@@ -520,7 +520,7 @@ cc_test(
     srcs = [
         "source_position_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":source_position",
         "@com_github_google_googletest//:gtest_main",
@@ -534,7 +534,7 @@ cc_test(
     srcs = [
         "unknown_attribute_set_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_attribute",
         ":cel_value",
@@ -549,7 +549,7 @@ cc_test(
     srcs = [
         "value_export_util_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_value",
         ":value_export_util",
@@ -568,7 +568,7 @@ cc_library(
     name = "unknown_function_result_set",
     srcs = ["unknown_function_result_set.cc"],
     hdrs = ["unknown_function_result_set.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_function",
         ":cel_options",
@@ -585,7 +585,7 @@ cc_test(
     srcs = [
         "unknown_function_result_set_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_function",
         ":cel_value",
@@ -602,7 +602,7 @@ cc_test(
 cc_library(
     name = "unknown_set",
     hdrs = ["unknown_set.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":unknown_attribute_set",
         ":unknown_function_result_set",
@@ -612,7 +612,7 @@ cc_library(
 cc_test(
     name = "unknown_set_test",
     srcs = ["unknown_set_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_attribute",
         ":unknown_attribute_set",
@@ -628,7 +628,7 @@ cc_library(
     name = "set_util",
     srcs = ["set_util.cc"],
     hdrs = ["set_util.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = ["//eval/public:cel_value"],
 )
 
@@ -638,7 +638,7 @@ cc_test(
     srcs = [
         "set_util_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_value",
         ":set_util",

--- a/eval/tests/BUILD
+++ b/eval/tests/BUILD
@@ -14,7 +14,7 @@ cc_test(
     srcs = [
         "benchmark_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     tags = ["manual"],
     deps = [
         ":request_context_cc_proto",
@@ -39,7 +39,7 @@ cc_test(
     srcs = [
         "end_to_end_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//base:status_macros",
         "//eval/public:activation",
@@ -60,7 +60,7 @@ cc_test(
     srcs = [
         "unknowns_end_to_end_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//base:status_macros",
         "//eval/public:activation",
@@ -94,7 +94,7 @@ cc_library(
     name = "mock_cel_expression",
     testonly = 1,
     hdrs = ["mock_cel_expression.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//eval/public:activation",
         "//eval/public:cel_expression",

--- a/internal/BUILD
+++ b/internal/BUILD
@@ -13,7 +13,7 @@ cc_library(
     hdrs = [
         "ref_countable.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":holder",
         ":specialize",
@@ -23,7 +23,7 @@ cc_library(
 cc_test(
     name = "ref_countable_test",
     srcs = ["ref_countable_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":ref_countable",
         "//testutil:util",
@@ -37,7 +37,7 @@ cc_library(
     hdrs = [
         "handle.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":hash_util",
         ":specialize",
@@ -47,7 +47,7 @@ cc_library(
 cc_test(
     name = "handle_test",
     srcs = ["handle_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":handle",
         "@com_github_google_googletest//:gtest_main",
@@ -60,7 +60,7 @@ cc_library(
     hdrs = [
         "holder.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":port",
         ":specialize",
@@ -72,7 +72,7 @@ cc_library(
 cc_test(
     name = "holder_test",
     srcs = ["holder_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":holder",
         ":types",
@@ -90,7 +90,7 @@ cc_library(
     hdrs = [
         "hash_util.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":port",
         ":specialize",
@@ -107,7 +107,7 @@ cc_library(
     hdrs = [
         "status_util.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_google_absl//absl/strings",
         "@com_google_googleapis//google/rpc:code_cc_proto",
@@ -120,7 +120,7 @@ cc_library(
     hdrs = [
         "visitor_util.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":specialize",
         ":types",
@@ -133,7 +133,7 @@ cc_library(
 cc_test(
     name = "visitor_util_test",
     srcs = ["visitor_util_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":adapter_util",
         ":visitor_util",
@@ -149,7 +149,7 @@ cc_library(
     hdrs = [
         "adapter_util.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":visitor_util",
     ],
@@ -161,7 +161,7 @@ cc_library(
     hdrs = [
         "cel_printer.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":specialize",
         ":types",
@@ -175,7 +175,7 @@ cc_library(
 cc_test(
     name = "cel_printer_test",
     srcs = ["cel_printer_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cel_printer",
         "@com_github_google_googletest//:gtest_main",
@@ -186,7 +186,7 @@ cc_library(
     name = "proto_util",
     srcs = ["proto_util.cc"],
     hdrs = ["proto_util.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":status_util",
         "//common:macros",
@@ -202,7 +202,7 @@ cc_library(
     name = "map_impl",
     srcs = ["map_impl.cc"],
     hdrs = ["map_impl.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":status_util",
         "//common:macros",
@@ -214,7 +214,7 @@ cc_library(
 cc_library(
     name = "list_impl",
     hdrs = ["list_impl.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":holder",
         "//common:macros",
@@ -225,7 +225,7 @@ cc_library(
 cc_library(
     name = "value_internal",
     hdrs = ["value_internal.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":adapter_util",
         ":cast",
@@ -244,7 +244,7 @@ cc_library(
 cc_test(
     name = "value_internal_test",
     srcs = ["value_internal_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":value_internal",
         "//testutil:util",
@@ -257,19 +257,19 @@ cc_test(
 cc_library(
     name = "port",
     hdrs = ["port.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
 )
 
 cc_library(
     name = "specialize",
     hdrs = ["specialize.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
 )
 
 cc_library(
     name = "cast",
     hdrs = ["cast.h"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":port",
         ":specialize",
@@ -282,7 +282,7 @@ cc_library(
 cc_test(
     name = "cast_test",
     srcs = ["cast_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":cast",
         "@com_github_google_googletest//:gtest_main",
@@ -294,7 +294,7 @@ cc_library(
     hdrs = [
         "types.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":port",
         ":specialize",
@@ -306,7 +306,7 @@ cc_library(
 cc_test(
     name = "types_test",
     srcs = ["types_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":types",
         "@com_github_google_googletest//:gtest_main",

--- a/parser/BUILD
+++ b/parser/BUILD
@@ -21,7 +21,7 @@ cc_library(
     ],
     copts = [
         "-fexceptions",
-        "-std=c++14",
+        "-std=c++17",
     ],
     deps = [
         ":cel_cc_parser",
@@ -45,7 +45,7 @@ cc_library(
     ],
     copts = [
         "-fexceptions",
-        "-std=c++14",
+        "-std=c++17",
     ],
     deps = [
         ":source_factory",
@@ -67,7 +67,7 @@ cc_library(
     ],
     copts = [
         "-fexceptions",
-        "-std=c++14",
+        "-std=c++17",
     ],
     deps = [
         ":cel_cc_parser",
@@ -94,7 +94,7 @@ cc_library(
     ],
     copts = [
         "-fexceptions",
-        "-std=c++14",
+        "-std=c++17",
     ],
     deps = [
         ":cel_cc_parser",
@@ -111,7 +111,7 @@ cc_library(
 cc_test(
     name = "parser_test",
     srcs = ["parser_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":parser",
         ":source_factory",

--- a/protoutil/BUILD
+++ b/protoutil/BUILD
@@ -13,7 +13,7 @@ cc_library(
     hdrs = [
         "type_registry.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//common:macros",
         "//common:parent_ref",
@@ -30,7 +30,7 @@ cc_library(
 cc_test(
     name = "type_registry_test",
     srcs = ["type_registry_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":type_registry",
         "//common:value",
@@ -50,7 +50,7 @@ cc_library(
     hdrs = [
         "converters.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":type_registry",
         "//common:macros",
@@ -73,7 +73,7 @@ cc_library(
 cc_test(
     name = "converters_test",
     srcs = ["converters_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     data = [
         "@com_google_cel_spec//testdata",
     ],

--- a/testutil/BUILD
+++ b/testutil/BUILD
@@ -15,7 +15,7 @@ cc_library(
     hdrs = [
         "test_data_util.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//common:type",
         "//common:value",
@@ -44,7 +44,7 @@ cc_library(
     hdrs = [
         "test_data_io.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//internal:status_util",
         "@com_github_google_googletest//:gtest_main",
@@ -69,7 +69,7 @@ cc_binary(
     srcs = [
         "test_data_gen.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         ":test_data_io",
         ":test_data_util",
@@ -87,7 +87,7 @@ cc_binary(
 cc_test(
     name = "test_data_test",
     srcs = ["test_data_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     data = [
         "@com_google_cel_spec//testdata",
     ],
@@ -105,7 +105,7 @@ cc_library(
     hdrs = [
         "util.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "@com_github_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -17,7 +17,7 @@ cc_library(
     hdrs = [
         "flatbuffers_backed_impl.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//eval/public:cel_value",
         "@com_github_google_flatbuffers//:flatbuffers",
@@ -36,7 +36,7 @@ cc_library(
     name = "flatbuffers_test_cc",
     srcs = [":flatbuffers_test"],
     hdrs = [":flatbuffers_test"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     features = ["-parse_headers"],
     linkstatic = True,
     deps = ["@com_github_google_flatbuffers//:runtime_cc"],
@@ -48,7 +48,7 @@ cc_test(
     srcs = [
         "flatbuffers_backed_impl_test.cc",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     data = [
         ":flatbuffers_reflection_out",
     ],

--- a/v1beta1/BUILD
+++ b/v1beta1/BUILD
@@ -15,7 +15,7 @@ cc_library(
     hdrs = [
         "converters.h",
     ],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     deps = [
         "//common:converters",
         "//common:macros",
@@ -37,7 +37,7 @@ cc_library(
 cc_test(
     name = "converters_test",
     srcs = ["converters_test.cc"],
-    copts = ["-std=c++14"],
+    copts = ["-std=c++17"],
     data = [
         "@com_google_cel_spec//testdata",
     ],


### PR DESCRIPTION
In the process of porting Envoy Proxy, a network proxy dependent on cel-cpp, to C++17, I have found out that we have to make the build flags change in cel-cpp to make it work. As far as I know, internally, google has switched to C++17 six months ago. So hopefully this will not be breaking any things and the switch will be painless. 

Signed-off-by: Yifan Yang <needyyang@google.com>