### PR TITLE
strings: fix invalid access with UTF8 verification, ensure absl::string_view compatibility

### DIFF
--- a/base/unilib.cc
+++ b/base/unilib.cc
@@ -6,6 +6,9 @@ namespace UniLib {
 
 // Detects whether a string is valid UTF-8.
 bool IsStructurallyValid(absl::string_view str) {
+  if (str.size() == 0) {
+    return true;
+  }
   const char *s = &str[0];
   const char *const sEnd = s + str.length();
   while (s < sEnd) {

--- a/bazel/abseil.patch
+++ b/bazel/abseil.patch
@@ -1,0 +1,42 @@
+# Force internal versions of std classes per
+# https://abseil.io/docs/cpp/guides/options
+diff --git a/absl/base/options.h b/absl/base/options.h
+index 230bf1e..6e1b9e5 100644
+--- a/absl/base/options.h
++++ b/absl/base/options.h
+@@ -100,7 +100,7 @@
+ // User code should not inspect this macro.  To check in the preprocessor if
+ // absl::any is a typedef of std::any, use the feature macro ABSL_USES_STD_ANY.
+
+-#define ABSL_OPTION_USE_STD_ANY 2
++#define ABSL_OPTION_USE_STD_ANY 0
+
+
+ // ABSL_OPTION_USE_STD_OPTIONAL
+@@ -127,7 +127,7 @@
+ // absl::optional is a typedef of std::optional, use the feature macro
+ // ABSL_USES_STD_OPTIONAL.
+
+-#define ABSL_OPTION_USE_STD_OPTIONAL 2
++#define ABSL_OPTION_USE_STD_OPTIONAL 0
+
+
+ // ABSL_OPTION_USE_STD_STRING_VIEW
+@@ -154,7 +154,7 @@
+ // absl::string_view is a typedef of std::string_view, use the feature macro
+ // ABSL_USES_STD_STRING_VIEW.
+
+-#define ABSL_OPTION_USE_STD_STRING_VIEW 2
++#define ABSL_OPTION_USE_STD_STRING_VIEW 0
+
+ // ABSL_OPTION_USE_STD_VARIANT
+ //
+@@ -180,7 +180,7 @@
+ // absl::variant is a typedef of std::variant, use the feature macro
+ // ABSL_USES_STD_VARIANT.
+
+-#define ABSL_OPTION_USE_STD_VARIANT 2
++#define ABSL_OPTION_USE_STD_VARIANT 0
+
+
+ // ABSL_OPTION_USE_INLINE_NAMESPACE

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -8,6 +8,8 @@ def base_deps():
     """Base evaluator and test dependencies."""
     http_archive(
         name = "com_google_absl",
+        patches = ["//bazel:abseil.patch"],
+        patch_args = ["-p1"],
         strip_prefix = "abseil-cpp-master",
         urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
     )

--- a/eval/public/structs/cel_proto_wrapper.cc
+++ b/eval/public/structs/cel_proto_wrapper.cc
@@ -548,7 +548,7 @@ absl::optional<const google::protobuf::Message*> MessageFromValue(const CelValue
     if (!result.has_value()) {
       return {};
     }
-    (*fields)[key] = field_value;
+    (*fields)[std::string(key)] = field_value;
   }
   return json_struct;
 }


### PR DESCRIPTION
Apply abseil patch to ensure that code does not depend on aliased std::string_view and absl::string_view.

Signed-off-by: Kuat Yessenov <kuat@google.com>