### PR TITLE
fix build

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -28,8 +28,8 @@ def base_deps():
 
     http_archive(
         name = "com_googlesource_code_re2",
-        strip_prefix = "re2-master",
-        urls = ["https://github.com/google/re2/archive/master.zip"],
+        strip_prefix = "re2-main",
+        urls = ["https://github.com/google/re2/archive/main.zip"],
     )
 
     PROTOBUF_VERSION = "3.14.0"


### PR DESCRIPTION
Master was renamed to main in re2.
Ref #125 

Signed-off-by: Kuat Yessenov <kuat@google.com>