### PR TITLE
Rename TRUE and FALSE

### DIFF
--- a/parser/Cel.g4
+++ b/parser/Cel.g4
@@ -73,8 +73,8 @@ literal
     | sign=MINUS? tok=NUM_FLOAT # Double
     | tok=STRING    # String
     | tok=BYTES     # Bytes
-    | tok=CELTRUE   # BoolTrue
-    | tok=CELFALSE  # BoolFalse
+    | tok=CEL_TRUE  # BoolTrue
+    | tok=CEL_FALSE # BoolFalse
     | tok=NUL       # Null
     ;
 
@@ -106,8 +106,8 @@ PLUS : '+';
 STAR : '*';
 SLASH : '/';
 PERCENT : '%';
-CELTRUE : 'true';
-CELFALSE : 'false';
+CEL_TRUE : 'true';
+CEL_FALSE : 'false';
 NUL : 'null';
 
 fragment BACKSLASH : '\\';

--- a/parser/Cel.g4
+++ b/parser/Cel.g4
@@ -73,8 +73,8 @@ literal
     | sign=MINUS? tok=NUM_FLOAT # Double
     | tok=STRING    # String
     | tok=BYTES     # Bytes
-    | tok=TRUE      # BoolTrue
-    | tok=FALSE     # BoolFalse
+    | tok=CELTRUE   # BoolTrue
+    | tok=CELFALSE  # BoolFalse
     | tok=NUL       # Null
     ;
 
@@ -106,8 +106,8 @@ PLUS : '+';
 STAR : '*';
 SLASH : '/';
 PERCENT : '%';
-TRUE : 'true';
-FALSE : 'false';
+CELTRUE : 'true';
+CELFALSE : 'false';
 NUL : 'null';
 
 fragment BACKSLASH : '\\';


### PR DESCRIPTION
This avoids conflicts with default macros defined by the Windows and
macOS SDKs.

Fixes: https://github.com/google/cel-cpp/issues/121