### PR TITLE
Make BaseActivation class move-constructible/assignable

### DIFF
--- a/eval/public/base_activation.h
+++ b/eval/public/base_activation.h
@@ -21,6 +21,10 @@ class BaseActivation {
   BaseActivation(const BaseActivation&) = delete;
   BaseActivation& operator=(const BaseActivation&) = delete;
 
+  // Move-constructible/move-assignable
+  BaseActivation(BaseActivation&& other) = default;
+  BaseActivation& operator=(BaseActivation&& other) = default;
+
   // Return a list of function overloads for the given name.
   virtual std::vector<const CelFunction*> FindFunctionOverloads(
       absl::string_view) const = 0;
@@ -49,7 +53,7 @@ class BaseActivation {
     return *empty;
   }
 
-  virtual ~BaseActivation() {}
+  virtual ~BaseActivation() = default;
 };
 
 }  // namespace google::api::expr::runtime


### PR DESCRIPTION
The copy constructor/assignment are explicitly deleted. These user-defined function will also delete implicitly-declared move constructor/assignment, which make this class not move-constructible/assignable. 

Bring them back by adding =default move constructor/assignment.

Also, change default destructor to use `=default` which is suggested by style guide.