### PR TITLE
Use ABSL_LOG macros over LOG macros

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -208,6 +208,7 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/types:variant",
+        "@com_google_absl//absl/utility",
         "@com_googlesource_code_re2//:re2",
     ],
 )

--- a/base/type.cc
+++ b/base/type.cc
@@ -101,6 +101,8 @@ absl::Span<const absl::string_view> Type::aliases() const {
       return static_cast<const ListType*>(this)->aliases();
     case Kind::kMap:
       return static_cast<const MapType*>(this)->aliases();
+    case Kind::kWrapper:
+      return static_cast<const WrapperType*>(this)->aliases();
     default:
       // Everything else does not support aliases.
       return absl::Span<const absl::string_view>();

--- a/base/types/wrapper_type.cc
+++ b/base/types/wrapper_type.cc
@@ -15,6 +15,8 @@
 #include "base/types/wrapper_type.h"
 
 #include "absl/base/optimization.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 
 namespace cel {
 
@@ -46,6 +48,20 @@ absl::string_view WrapperType::name() const {
   }
 }
 
+absl::Span<const absl::string_view> WrapperType::aliases() const {
+  switch (base_internal::Metadata::GetInlineVariant<Kind>(*this)) {
+    case Kind::kDouble:
+      return static_cast<const DoubleWrapperType*>(this)->aliases();
+    case Kind::kInt:
+      return static_cast<const IntWrapperType*>(this)->aliases();
+    case Kind::kUint:
+      return static_cast<const UintWrapperType*>(this)->aliases();
+    default:
+      // The other wrappers do not have aliases.
+      return absl::Span<const absl::string_view>();
+  }
+}
+
 const Handle<Type>& WrapperType::wrapped() const {
   switch (base_internal::Metadata::GetInlineVariant<Kind>(*this)) {
     case Kind::kBool:
@@ -64,6 +80,24 @@ const Handle<Type>& WrapperType::wrapped() const {
       // There are only 6 wrapper types.
       ABSL_UNREACHABLE();
   }
+}
+
+absl::Span<const absl::string_view> DoubleWrapperType::aliases() const {
+  static constexpr absl::string_view kAliases[] = {
+      "google.protobuf.FloatValue"};
+  return absl::MakeConstSpan(kAliases);
+}
+
+absl::Span<const absl::string_view> IntWrapperType::aliases() const {
+  static constexpr absl::string_view kAliases[] = {
+      "google.protobuf.Int32Value"};
+  return absl::MakeConstSpan(kAliases);
+}
+
+absl::Span<const absl::string_view> UintWrapperType::aliases() const {
+  static constexpr absl::string_view kAliases[] = {
+      "google.protobuf.UInt32Value"};
+  return absl::MakeConstSpan(kAliases);
 }
 
 }  // namespace cel

--- a/base/types/wrapper_type.h
+++ b/base/types/wrapper_type.h
@@ -22,6 +22,7 @@
 #include "absl/base/attributes.h"
 #include "absl/log/absl_check.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "base/internal/data.h"
 #include "base/kind.h"
 #include "base/type.h"
@@ -69,12 +70,16 @@ class WrapperType : public Type, base_internal::InlineData {
   const Handle<Type>& wrapped() const;
 
  private:
+  friend class Type;
   friend class BoolWrapperType;
   friend class BytesWrapperType;
   friend class DoubleWrapperType;
   friend class IntWrapperType;
   friend class StringWrapperType;
   friend class UintWrapperType;
+
+  // See Type::aliases().
+  absl::Span<const absl::string_view> aliases() const;
 
   using Base::Base;
 };
@@ -189,6 +194,7 @@ class DoubleWrapperType final : public WrapperType {
   const Handle<DoubleType>& wrapped() const { return DoubleType::Get(); }
 
  private:
+  friend class WrapperType;
   friend class TypeFactory;
   template <size_t Size, size_t Align>
   friend struct base_internal::AnyData;
@@ -202,6 +208,9 @@ class DoubleWrapperType final : public WrapperType {
        << base_internal::kInlineVariantShift);
 
   constexpr DoubleWrapperType() : WrapperType(kMetadata) {}
+
+  // See Type::aliases().
+  absl::Span<const absl::string_view> aliases() const;
 };
 
 class IntWrapperType final : public WrapperType {
@@ -226,6 +235,7 @@ class IntWrapperType final : public WrapperType {
   const Handle<IntType>& wrapped() const { return IntType::Get(); }
 
  private:
+  friend class WrapperType;
   friend class TypeFactory;
   template <size_t Size, size_t Align>
   friend struct base_internal::AnyData;
@@ -239,6 +249,9 @@ class IntWrapperType final : public WrapperType {
        << base_internal::kInlineVariantShift);
 
   constexpr IntWrapperType() : WrapperType(kMetadata) {}
+
+  // See Type::aliases().
+  absl::Span<const absl::string_view> aliases() const;
 };
 
 class StringWrapperType final : public WrapperType {
@@ -300,6 +313,7 @@ class UintWrapperType final : public WrapperType {
   const Handle<UintType>& wrapped() const { return UintType::Get(); }
 
  private:
+  friend class WrapperType;
   friend class TypeFactory;
   template <size_t Size, size_t Align>
   friend struct base_internal::AnyData;
@@ -313,6 +327,9 @@ class UintWrapperType final : public WrapperType {
        << base_internal::kInlineVariantShift);
 
   constexpr UintWrapperType() : WrapperType(kMetadata) {}
+
+  // See Type::aliases().
+  absl::Span<const absl::string_view> aliases() const;
 };
 
 extern template class Handle<WrapperType>;

--- a/base/values/map_value_builder_test.cc
+++ b/base/values/map_value_builder_test.cc
@@ -59,13 +59,13 @@ TEST(MapValueBuilder, UnspecializedUnspecialized) {
               IsOkAndHolds(IsTrue()));  // lvalue, lvalue
   EXPECT_THAT(map_builder.Update(key, make_value()),
               IsOkAndHolds(IsTrue()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, value),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
               IsOkAndHolds(IsFalse()));  // lvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, make_value()),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value()),
               IsOkAndHolds(IsFalse()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key("bar"), value),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), value),
               IsOkAndHolds(IsTrue()));  // rvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key("bar"), make_value("baz")),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), make_value("baz")),
               IsOkAndHolds(IsFalse()));  // rvalue, rvalue
   EXPECT_TRUE(map_builder.Has(key));
   EXPECT_FALSE(map_builder.empty());
@@ -89,6 +89,11 @@ TEST(MapValueBuilder, UnspecializedUnspecialized) {
   EXPECT_EQ((*entry).As<BytesValue>()->ToString(), "baz");
   EXPECT_EQ(map->DebugString(),
             "{\"\": b\"\", \"foo\": b\"\", \"bar\": b\"baz\"}");
+  ASSERT_OK_AND_ASSIGN(auto keys,
+                       map->ListKeys(MapValue::ListKeysContext(value_factory)));
+  EXPECT_FALSE(keys->empty());
+  EXPECT_EQ(keys->size(), 3);
+  EXPECT_EQ(keys->DebugString(), "[\"\", \"foo\", \"bar\"]");
 }
 
 TEST(MapValueBuilder, UnspecializedGeneric) {
@@ -123,13 +128,13 @@ TEST(MapValueBuilder, UnspecializedGeneric) {
               IsOkAndHolds(IsTrue()));  // lvalue, lvalue
   EXPECT_THAT(map_builder.Update(key, make_value()),
               IsOkAndHolds(IsTrue()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, value),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
               IsOkAndHolds(IsFalse()));  // lvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, make_value()),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value()),
               IsOkAndHolds(IsFalse()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key("bar"), value),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), value),
               IsOkAndHolds(IsTrue()));  // rvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key("bar"), make_value("baz")),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), make_value("baz")),
               IsOkAndHolds(IsFalse()));  // rvalue, rvalue
   EXPECT_TRUE(map_builder.Has(key));
   EXPECT_FALSE(map_builder.empty());
@@ -153,6 +158,11 @@ TEST(MapValueBuilder, UnspecializedGeneric) {
   EXPECT_EQ((*entry).As<BytesValue>()->ToString(), "baz");
   EXPECT_EQ(map->DebugString(),
             "{\"\": b\"\", \"foo\": b\"\", \"bar\": b\"baz\"}");
+  ASSERT_OK_AND_ASSIGN(auto keys,
+                       map->ListKeys(MapValue::ListKeysContext(value_factory)));
+  EXPECT_FALSE(keys->empty());
+  EXPECT_EQ(keys->size(), 3);
+  EXPECT_EQ(keys->DebugString(), "[\"\", \"foo\", \"bar\"]");
 }
 
 TEST(MapValueBuilder, GenericUnspecialized) {
@@ -187,13 +197,13 @@ TEST(MapValueBuilder, GenericUnspecialized) {
               IsOkAndHolds(IsTrue()));  // lvalue, lvalue
   EXPECT_THAT(map_builder.Update(key, make_value()),
               IsOkAndHolds(IsTrue()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, value),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
               IsOkAndHolds(IsFalse()));  // lvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, make_value()),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value()),
               IsOkAndHolds(IsFalse()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key("bar"), value),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), value),
               IsOkAndHolds(IsTrue()));  // rvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key("bar"), make_value("baz")),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), make_value("baz")),
               IsOkAndHolds(IsFalse()));  // rvalue, rvalue
   EXPECT_TRUE(map_builder.Has(key));
   EXPECT_FALSE(map_builder.empty());
@@ -217,6 +227,11 @@ TEST(MapValueBuilder, GenericUnspecialized) {
   EXPECT_EQ((*entry).As<BytesValue>()->ToString(), "baz");
   EXPECT_EQ(map->DebugString(),
             "{\"\": b\"\", \"foo\": b\"\", \"bar\": b\"baz\"}");
+  ASSERT_OK_AND_ASSIGN(auto keys,
+                       map->ListKeys(MapValue::ListKeysContext(value_factory)));
+  EXPECT_FALSE(keys->empty());
+  EXPECT_EQ(keys->size(), 3);
+  EXPECT_EQ(keys->DebugString(), "[\"\", \"foo\", \"bar\"]");
 }
 
 TEST(MapValueBuilder, GenericGeneric) {
@@ -251,13 +266,13 @@ TEST(MapValueBuilder, GenericGeneric) {
               IsOkAndHolds(IsTrue()));  // lvalue, lvalue
   EXPECT_THAT(map_builder.Update(key, make_value()),
               IsOkAndHolds(IsTrue()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, value),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
               IsOkAndHolds(IsFalse()));  // lvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, make_value()),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value()),
               IsOkAndHolds(IsFalse()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key("bar"), value),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), value),
               IsOkAndHolds(IsTrue()));  // rvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key("bar"), make_value("baz")),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), make_value("baz")),
               IsOkAndHolds(IsFalse()));  // rvalue, rvalue
   EXPECT_TRUE(map_builder.Has(key));
   EXPECT_FALSE(map_builder.empty());
@@ -281,13 +296,278 @@ TEST(MapValueBuilder, GenericGeneric) {
   EXPECT_EQ((*entry).As<BytesValue>()->ToString(), "baz");
   EXPECT_EQ(map->DebugString(),
             "{\"\": b\"\", \"foo\": b\"\", \"bar\": b\"baz\"}");
+  ASSERT_OK_AND_ASSIGN(auto keys,
+                       map->ListKeys(MapValue::ListKeysContext(value_factory)));
+  EXPECT_FALSE(keys->empty());
+  EXPECT_EQ(keys->size(), 3);
+  EXPECT_EQ(keys->DebugString(), "[\"\", \"foo\", \"bar\"]");
+}
+
+TEST(MapValueBuilder, UnspecializedSpecialized) {
+  TypeFactory type_factory(MemoryManager::Global());
+  TypeManager type_manager(type_factory, TypeProvider::Builtin());
+  ValueFactory value_factory(type_manager);
+  auto map_builder = MapValueBuilder<StringValue, IntValue>(
+      value_factory, type_factory.GetStringType(), type_factory.GetIntType());
+  auto make_key = [&](absl::string_view value =
+                          absl::string_view()) -> Handle<StringValue> {
+    return value_factory.CreateStringValue(value).value();
+  };
+  auto key = make_key();
+  auto make_value = [&](int64_t value = 0) -> Handle<IntValue> {
+    return value_factory.CreateIntValue(value);
+  };
+  auto value = make_value();
+  EXPECT_THAT(map_builder.Update(key, value),
+              IsOkAndHolds(IsFalse()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Update(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.Insert(key, value),
+              IsOkAndHolds(IsTrue()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Insert(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.Insert(make_key("foo"), value),
+              IsOkAndHolds(IsTrue()));  // rvalue, lvalue
+  EXPECT_THAT(map_builder.Insert(make_key("foo"), make_value()),
+              IsOkAndHolds(IsFalse()));  // rvalue, rvalue
+  EXPECT_THAT(map_builder.Update(key, value),
+              IsOkAndHolds(IsTrue()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Update(key, make_value()),
+              IsOkAndHolds(IsTrue()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
+              IsOkAndHolds(IsFalse()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), value),
+              IsOkAndHolds(IsTrue()));  // rvalue, lvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), make_value(1)),
+              IsOkAndHolds(IsFalse()));  // rvalue, rvalue
+  EXPECT_TRUE(map_builder.Has(key));
+  EXPECT_FALSE(map_builder.empty());
+  EXPECT_EQ(map_builder.size(), 3);
+  EXPECT_EQ(map_builder.DebugString(), "{\"\": 0, \"foo\": 0, \"bar\": 1}");
+  ASSERT_OK_AND_ASSIGN(auto map, std::move(map_builder).Build());
+  EXPECT_FALSE(map->empty());
+  EXPECT_EQ(map->size(), 3);
+  ASSERT_OK_AND_ASSIGN(auto entry,
+                       map->Get(MapValue::GetContext(value_factory), key));
+  EXPECT_TRUE((*entry)->Is<IntValue>());
+  EXPECT_EQ((*entry).As<IntValue>()->value(), 0);
+  ASSERT_OK_AND_ASSIGN(
+      entry, map->Get(MapValue::GetContext(value_factory), make_key("foo")));
+  EXPECT_TRUE((*entry)->Is<IntValue>());
+  EXPECT_EQ((*entry).As<IntValue>()->value(), 0);
+  ASSERT_OK_AND_ASSIGN(
+      entry, map->Get(MapValue::GetContext(value_factory), make_key("bar")));
+  EXPECT_TRUE((*entry)->Is<IntValue>());
+  EXPECT_EQ((*entry).As<IntValue>()->value(), 1);
+  EXPECT_EQ(map->DebugString(), "{\"\": 0, \"foo\": 0, \"bar\": 1}");
+  ASSERT_OK_AND_ASSIGN(auto keys,
+                       map->ListKeys(MapValue::ListKeysContext(value_factory)));
+  EXPECT_FALSE(keys->empty());
+  EXPECT_EQ(keys->size(), 3);
+  EXPECT_EQ(keys->DebugString(), "[\"\", \"foo\", \"bar\"]");
+}
+
+TEST(MapValueBuilder, GenericSpecialized) {
+  TypeFactory type_factory(MemoryManager::Global());
+  TypeManager type_manager(type_factory, TypeProvider::Builtin());
+  ValueFactory value_factory(type_manager);
+  auto map_builder = MapValueBuilder<Value, IntValue>(
+      value_factory, type_factory.GetStringType(), type_factory.GetIntType());
+  auto make_key = [&](absl::string_view value =
+                          absl::string_view()) -> Handle<Value> {
+    return value_factory.CreateStringValue(value).value();
+  };
+  auto key = make_key();
+  auto make_value = [&](int64_t value = 0) -> Handle<IntValue> {
+    return value_factory.CreateIntValue(value);
+  };
+  auto value = make_value();
+  EXPECT_THAT(map_builder.Update(key, value),
+              IsOkAndHolds(IsFalse()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Update(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.Insert(key, value),
+              IsOkAndHolds(IsTrue()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Insert(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.Insert(make_key("foo"), value),
+              IsOkAndHolds(IsTrue()));  // rvalue, lvalue
+  EXPECT_THAT(map_builder.Insert(make_key("foo"), make_value()),
+              IsOkAndHolds(IsFalse()));  // rvalue, rvalue
+  EXPECT_THAT(map_builder.Update(key, value),
+              IsOkAndHolds(IsTrue()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Update(key, make_value()),
+              IsOkAndHolds(IsTrue()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
+              IsOkAndHolds(IsFalse()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), value),
+              IsOkAndHolds(IsTrue()));  // rvalue, lvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key("bar"), make_value(1)),
+              IsOkAndHolds(IsFalse()));  // rvalue, rvalue
+  EXPECT_TRUE(map_builder.Has(key));
+  EXPECT_FALSE(map_builder.empty());
+  EXPECT_EQ(map_builder.size(), 3);
+  EXPECT_EQ(map_builder.DebugString(), "{\"\": 0, \"foo\": 0, \"bar\": 1}");
+  ASSERT_OK_AND_ASSIGN(auto map, std::move(map_builder).Build());
+  EXPECT_FALSE(map->empty());
+  EXPECT_EQ(map->size(), 3);
+  ASSERT_OK_AND_ASSIGN(auto entry,
+                       map->Get(MapValue::GetContext(value_factory), key));
+  EXPECT_TRUE((*entry)->Is<IntValue>());
+  EXPECT_EQ((*entry).As<IntValue>()->value(), 0);
+  ASSERT_OK_AND_ASSIGN(
+      entry, map->Get(MapValue::GetContext(value_factory), make_key("foo")));
+  EXPECT_TRUE((*entry)->Is<IntValue>());
+  EXPECT_EQ((*entry).As<IntValue>()->value(), 0);
+  ASSERT_OK_AND_ASSIGN(
+      entry, map->Get(MapValue::GetContext(value_factory), make_key("bar")));
+  EXPECT_TRUE((*entry)->Is<IntValue>());
+  EXPECT_EQ((*entry).As<IntValue>()->value(), 1);
+  EXPECT_EQ(map->DebugString(), "{\"\": 0, \"foo\": 0, \"bar\": 1}");
+  ASSERT_OK_AND_ASSIGN(auto keys,
+                       map->ListKeys(MapValue::ListKeysContext(value_factory)));
+  EXPECT_FALSE(keys->empty());
+  EXPECT_EQ(keys->size(), 3);
+  EXPECT_EQ(keys->DebugString(), "[\"\", \"foo\", \"bar\"]");
+}
+
+TEST(MapValueBuilder, SpecializedUnspecialized) {
+  TypeFactory type_factory(MemoryManager::Global());
+  TypeManager type_manager(type_factory, TypeProvider::Builtin());
+  ValueFactory value_factory(type_manager);
+  auto map_builder = MapValueBuilder<IntValue, StringValue>(
+      value_factory, type_factory.GetIntType(), type_factory.GetStringType());
+  auto make_key = [&](int64_t value = 0) -> Handle<IntValue> {
+    return value_factory.CreateIntValue(value);
+  };
+  auto key = make_key();
+  auto make_value = [&](absl::string_view value =
+                            absl::string_view()) -> Handle<StringValue> {
+    return value_factory.CreateStringValue(value).value();
+  };
+  auto value = make_value();
+  EXPECT_THAT(map_builder.Update(key, value),
+              IsOkAndHolds(IsFalse()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Update(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.Insert(key, value),
+              IsOkAndHolds(IsTrue()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Insert(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.Insert(make_key(1), value),
+              IsOkAndHolds(IsTrue()));  // rvalue, lvalue
+  EXPECT_THAT(map_builder.Insert(make_key(1), make_value()),
+              IsOkAndHolds(IsFalse()));  // rvalue, rvalue
+  EXPECT_THAT(map_builder.Update(key, value),
+              IsOkAndHolds(IsTrue()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Update(key, make_value()),
+              IsOkAndHolds(IsTrue()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
+              IsOkAndHolds(IsFalse()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key(2), value),
+              IsOkAndHolds(IsTrue()));  // rvalue, lvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key(2), make_value("foo")),
+              IsOkAndHolds(IsFalse()));  // rvalue, rvalue
+  EXPECT_TRUE(map_builder.Has(key));
+  EXPECT_FALSE(map_builder.empty());
+  EXPECT_EQ(map_builder.size(), 3);
+  EXPECT_EQ(map_builder.DebugString(), "{0: \"\", 1: \"\", 2: \"foo\"}");
+  ASSERT_OK_AND_ASSIGN(auto map, std::move(map_builder).Build());
+  EXPECT_FALSE(map->empty());
+  EXPECT_EQ(map->size(), 3);
+  ASSERT_OK_AND_ASSIGN(auto entry,
+                       map->Get(MapValue::GetContext(value_factory), key));
+  EXPECT_TRUE((*entry)->Is<StringValue>());
+  EXPECT_TRUE((*entry).As<StringValue>()->empty());
+  ASSERT_OK_AND_ASSIGN(
+      entry, map->Get(MapValue::GetContext(value_factory), make_key(1)));
+  EXPECT_TRUE((*entry)->Is<StringValue>());
+  EXPECT_TRUE((*entry).As<StringValue>()->empty());
+  ASSERT_OK_AND_ASSIGN(
+      entry, map->Get(MapValue::GetContext(value_factory), make_key(2)));
+  EXPECT_TRUE((*entry)->Is<StringValue>());
+  EXPECT_EQ((*entry).As<StringValue>()->ToString(), "foo");
+  EXPECT_EQ(map->DebugString(), "{0: \"\", 1: \"\", 2: \"foo\"}");
+  ASSERT_OK_AND_ASSIGN(auto keys,
+                       map->ListKeys(MapValue::ListKeysContext(value_factory)));
+  EXPECT_FALSE(keys->empty());
+  EXPECT_EQ(keys->size(), 3);
+  EXPECT_EQ(keys->DebugString(), "[0, 1, 2]");
+}
+
+TEST(MapValueBuilder, SpecializedGeneric) {
+  TypeFactory type_factory(MemoryManager::Global());
+  TypeManager type_manager(type_factory, TypeProvider::Builtin());
+  ValueFactory value_factory(type_manager);
+  auto map_builder = MapValueBuilder<IntValue, Value>(
+      value_factory, type_factory.GetIntType(), type_factory.GetStringType());
+  auto make_key = [&](int64_t value = 0) -> Handle<IntValue> {
+    return value_factory.CreateIntValue(value);
+  };
+  auto key = make_key();
+  auto make_value = [&](absl::string_view value =
+                            absl::string_view()) -> Handle<Value> {
+    return value_factory.CreateStringValue(value).value();
+  };
+  auto value = make_value();
+  EXPECT_THAT(map_builder.Update(key, value),
+              IsOkAndHolds(IsFalse()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Update(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.Insert(key, value),
+              IsOkAndHolds(IsTrue()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Insert(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.Insert(make_key(1), value),
+              IsOkAndHolds(IsTrue()));  // rvalue, lvalue
+  EXPECT_THAT(map_builder.Insert(make_key(1), make_value()),
+              IsOkAndHolds(IsFalse()));  // rvalue, rvalue
+  EXPECT_THAT(map_builder.Update(key, value),
+              IsOkAndHolds(IsTrue()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.Update(key, make_value()),
+              IsOkAndHolds(IsTrue()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
+              IsOkAndHolds(IsFalse()));  // lvalue, lvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value()),
+              IsOkAndHolds(IsFalse()));  // lvalue, rvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key(2), value),
+              IsOkAndHolds(IsTrue()));  // rvalue, lvalue
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key(2), make_value("foo")),
+              IsOkAndHolds(IsFalse()));  // rvalue, rvalue
+  EXPECT_TRUE(map_builder.Has(key));
+  EXPECT_FALSE(map_builder.empty());
+  EXPECT_EQ(map_builder.size(), 3);
+  EXPECT_EQ(map_builder.DebugString(), "{0: \"\", 1: \"\", 2: \"foo\"}");
+  ASSERT_OK_AND_ASSIGN(auto map, std::move(map_builder).Build());
+  EXPECT_FALSE(map->empty());
+  EXPECT_EQ(map->size(), 3);
+  ASSERT_OK_AND_ASSIGN(auto entry,
+                       map->Get(MapValue::GetContext(value_factory), key));
+  EXPECT_TRUE((*entry)->Is<StringValue>());
+  EXPECT_TRUE((*entry).As<StringValue>()->empty());
+  ASSERT_OK_AND_ASSIGN(
+      entry, map->Get(MapValue::GetContext(value_factory), make_key(1)));
+  EXPECT_TRUE((*entry)->Is<StringValue>());
+  EXPECT_TRUE((*entry).As<StringValue>()->empty());
+  ASSERT_OK_AND_ASSIGN(
+      entry, map->Get(MapValue::GetContext(value_factory), make_key(2)));
+  EXPECT_TRUE((*entry)->Is<StringValue>());
+  EXPECT_EQ((*entry).As<StringValue>()->ToString(), "foo");
+  EXPECT_EQ(map->DebugString(), "{0: \"\", 1: \"\", 2: \"foo\"}");
 }
 
 template <typename Key, typename Value, typename GetKey, typename GetValue,
           typename MakeKey, typename MakeValue>
 void TestMapBuilder(GetKey get_key, GetValue get_value, MakeKey make_key1,
                     MakeKey make_key2, MakeKey make_key3, MakeValue make_value1,
-                    MakeValue make_value2, absl::string_view debug_string) {
+                    MakeValue make_value2, absl::string_view debug_string,
+                    absl::string_view keys_debug_string) {
   TypeFactory type_factory(MemoryManager::Global());
   TypeManager type_manager(type_factory, TypeProvider::Builtin());
   ValueFactory value_factory(type_manager);
@@ -312,13 +592,13 @@ void TestMapBuilder(GetKey get_key, GetValue get_value, MakeKey make_key1,
               IsOkAndHolds(IsTrue()));  // lvalue, lvalue
   EXPECT_THAT(map_builder.Update(key, make_value1(value_factory)),
               IsOkAndHolds(IsTrue()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, value),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, value),
               IsOkAndHolds(IsFalse()));  // lvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(key, make_value1(value_factory)),
+  EXPECT_THAT(map_builder.InsertOrAssign(key, make_value1(value_factory)),
               IsOkAndHolds(IsFalse()));  // lvalue, rvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key3(value_factory), value),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key3(value_factory), value),
               IsOkAndHolds(IsTrue()));  // rvalue, lvalue
-  EXPECT_THAT(map_builder.InsertOrUpdate(make_key3(value_factory),
+  EXPECT_THAT(map_builder.InsertOrAssign(make_key3(value_factory),
                                          make_value2(value_factory)),
               IsOkAndHolds(IsFalse()));  // rvalue, rvalue
   EXPECT_TRUE(map_builder.Has(key));
@@ -344,6 +624,22 @@ void TestMapBuilder(GetKey get_key, GetValue get_value, MakeKey make_key1,
   EXPECT_EQ(*((*entry).template As<Value>()),
             *((make_value2(value_factory)).template As<Value>()));
   EXPECT_EQ(map->DebugString(), debug_string);
+  ASSERT_OK_AND_ASSIGN(auto keys,
+                       map->ListKeys(MapValue::ListKeysContext(value_factory)));
+  EXPECT_FALSE(keys->empty());
+  EXPECT_EQ(keys->size(), 3);
+  ASSERT_OK_AND_ASSIGN(auto element,
+                       keys->Get(ListValue::GetContext(value_factory), 0));
+  EXPECT_EQ((*element).template As<Key>(), (*key).template As<Key>());
+  ASSERT_OK_AND_ASSIGN(element,
+                       keys->Get(ListValue::GetContext(value_factory), 1));
+  EXPECT_EQ((*element).template As<Key>(),
+            (*make_key2(value_factory)).template As<Key>());
+  ASSERT_OK_AND_ASSIGN(element,
+                       keys->Get(ListValue::GetContext(value_factory), 2));
+  EXPECT_EQ((*element).template As<Key>(),
+            (*make_key3(value_factory)).template As<Key>());
+  EXPECT_EQ(keys->DebugString(), keys_debug_string);
 }
 
 template <bool C>
@@ -383,35 +679,35 @@ TEST(MapValueBuilder, IntBool) {
   TestMapBuilder<IntValue, BoolValue>(
       &TypeFactory::GetIntType, &TypeFactory::GetBoolType, MakeIntValue<0>,
       MakeIntValue<1>, MakeIntValue<2>, MakeBoolValue<false>,
-      MakeBoolValue<true>, "{0: false, 1: false, 2: true}");
+      MakeBoolValue<true>, "{0: false, 1: false, 2: true}", "[0, 1, 2]");
 }
 
 TEST(MapValueBuilder, IntInt) {
   TestMapBuilder<IntValue, IntValue>(
       &TypeFactory::GetIntType, &TypeFactory::GetIntType, MakeIntValue<0>,
       MakeIntValue<1>, MakeIntValue<2>, MakeIntValue<0>, MakeIntValue<1>,
-      "{0: 0, 1: 0, 2: 1}");
+      "{0: 0, 1: 0, 2: 1}", "[0, 1, 2]");
 }
 
 TEST(MapValueBuilder, IntUint) {
   TestMapBuilder<IntValue, UintValue>(
       &TypeFactory::GetIntType, &TypeFactory::GetUintType, MakeIntValue<0>,
       MakeIntValue<1>, MakeIntValue<2>, MakeUintValue<0>, MakeUintValue<1>,
-      "{0: 0u, 1: 0u, 2: 1u}");
+      "{0: 0u, 1: 0u, 2: 1u}", "[0, 1, 2]");
 }
 
 TEST(MapValueBuilder, IntDouble) {
   TestMapBuilder<IntValue, DoubleValue>(
       &TypeFactory::GetIntType, &TypeFactory::GetDoubleType, MakeIntValue<0>,
       MakeIntValue<1>, MakeIntValue<2>, MakeDoubleValue(0.0),
-      MakeDoubleValue(1.0), "{0: 0.0, 1: 0.0, 2: 1.0}");
+      MakeDoubleValue(1.0), "{0: 0.0, 1: 0.0, 2: 1.0}", "[0, 1, 2]");
 }
 
 TEST(MapValueBuilder, IntDuration) {
   TestMapBuilder<IntValue, DurationValue>(
       &TypeFactory::GetIntType, &TypeFactory::GetDurationType, MakeIntValue<0>,
       MakeIntValue<1>, MakeIntValue<2>, MakeDurationValue(absl::ZeroDuration()),
-      MakeDurationValue(absl::Seconds(1)), "{0: 0, 1: 0, 2: 1s}");
+      MakeDurationValue(absl::Seconds(1)), "{0: 0, 1: 0, 2: 1s}", "[0, 1, 2]");
 }
 
 TEST(MapValueBuilder, IntTimestamp) {
@@ -420,35 +716,36 @@ TEST(MapValueBuilder, IntTimestamp) {
       MakeIntValue<1>, MakeIntValue<2>, MakeTimestampValue(absl::UnixEpoch()),
       MakeTimestampValue(absl::UnixEpoch() + absl::Seconds(1)),
       "{0: 1970-01-01T00:00:00Z, 1: 1970-01-01T00:00:00Z, 2: "
-      "1970-01-01T00:00:01Z}");
+      "1970-01-01T00:00:01Z}",
+      "[0, 1, 2]");
 }
 
 TEST(MapValueBuilder, UintBool) {
   TestMapBuilder<UintValue, BoolValue>(
       &TypeFactory::GetUintType, &TypeFactory::GetBoolType, MakeUintValue<0>,
       MakeUintValue<1>, MakeUintValue<2>, MakeBoolValue<false>,
-      MakeBoolValue<true>, "{0u: false, 1u: false, 2u: true}");
+      MakeBoolValue<true>, "{0u: false, 1u: false, 2u: true}", "[0u, 1u, 2u]");
 }
 
 TEST(MapValueBuilder, UintInt) {
   TestMapBuilder<UintValue, IntValue>(
       &TypeFactory::GetUintType, &TypeFactory::GetIntType, MakeUintValue<0>,
       MakeUintValue<1>, MakeUintValue<2>, MakeIntValue<0>, MakeIntValue<1>,
-      "{0u: 0, 1u: 0, 2u: 1}");
+      "{0u: 0, 1u: 0, 2u: 1}", "[0u, 1u, 2u]");
 }
 
 TEST(MapValueBuilder, UintUint) {
   TestMapBuilder<UintValue, UintValue>(
       &TypeFactory::GetUintType, &TypeFactory::GetUintType, MakeUintValue<0>,
       MakeUintValue<1>, MakeUintValue<2>, MakeUintValue<0>, MakeUintValue<1>,
-      "{0u: 0u, 1u: 0u, 2u: 1u}");
+      "{0u: 0u, 1u: 0u, 2u: 1u}", "[0u, 1u, 2u]");
 }
 
 TEST(MapValueBuilder, UintDouble) {
   TestMapBuilder<UintValue, DoubleValue>(
       &TypeFactory::GetUintType, &TypeFactory::GetDoubleType, MakeUintValue<0>,
       MakeUintValue<1>, MakeUintValue<2>, MakeDoubleValue(0.0),
-      MakeDoubleValue(1.0), "{0u: 0.0, 1u: 0.0, 2u: 1.0}");
+      MakeDoubleValue(1.0), "{0u: 0.0, 1u: 0.0, 2u: 1.0}", "[0u, 1u, 2u]");
 }
 
 TEST(MapValueBuilder, UintDuration) {
@@ -456,7 +753,8 @@ TEST(MapValueBuilder, UintDuration) {
       &TypeFactory::GetUintType, &TypeFactory::GetDurationType,
       MakeUintValue<0>, MakeUintValue<1>, MakeUintValue<2>,
       MakeDurationValue(absl::ZeroDuration()),
-      MakeDurationValue(absl::Seconds(1)), "{0u: 0, 1u: 0, 2u: 1s}");
+      MakeDurationValue(absl::Seconds(1)), "{0u: 0, 1u: 0, 2u: 1s}",
+      "[0u, 1u, 2u]");
 }
 
 TEST(MapValueBuilder, UintTimestamp) {
@@ -466,10 +764,9 @@ TEST(MapValueBuilder, UintTimestamp) {
       MakeTimestampValue(absl::UnixEpoch()),
       MakeTimestampValue(absl::UnixEpoch() + absl::Seconds(1)),
       "{0u: 1970-01-01T00:00:00Z, 1u: 1970-01-01T00:00:00Z, 2u: "
-      "1970-01-01T00:00:01Z}");
+      "1970-01-01T00:00:01Z}",
+      "[0u, 1u, 2u]");
 }
-
-// TODO(issues/5): add <Primitive>Generic, Generic<Primitive>, and friends
 
 }  // namespace
 }  // namespace cel

--- a/eval/compiler/constant_folding.cc
+++ b/eval/compiler/constant_folding.cc
@@ -359,7 +359,7 @@ class ConstantFoldingTransform {
     }
 
     bool operator()(absl::monostate) {
-      LOG(ERROR) << "Unsupported Expr kind";
+      ABSL_LOG(ERROR) << "Unsupported Expr kind";
       return false;
     }
 

--- a/eval/compiler/flat_expr_builder_test.cc
+++ b/eval/compiler/flat_expr_builder_test.cc
@@ -1973,7 +1973,7 @@ TEST(FlatExprBuilderTest, CustomDescriptorPoolForSelect) {
 std::pair<google::protobuf::Message*, const google::protobuf::Reflection*> CreateTestMessage(
     const google::protobuf::DescriptorPool& descriptor_pool,
     google::protobuf::MessageFactory& message_factory, absl::string_view name) {
-  const google::protobuf::Descriptor* desc = descriptor_pool.FindMessageTypeByName(std::string(name));
+  const google::protobuf::Descriptor* desc = descriptor_pool.FindMessageTypeByName(name);
   const google::protobuf::Message* message_prototype = message_factory.GetPrototype(desc);
   google::protobuf::Message* message = message_prototype->New();
   const google::protobuf::Reflection* refl = message->GetReflection();

--- a/eval/eval/evaluator_core.cc
+++ b/eval/eval/evaluator_core.cc
@@ -51,7 +51,7 @@ const ExpressionStep* ExecutionFrame::Next() {
 
   if (pc_ < end_pos) return execution_path_[pc_++].get();
   if (pc_ > end_pos) {
-    LOG(ERROR) << "Attempting to step beyond the end of execution path.";
+    ABSL_LOG(ERROR) << "Attempting to step beyond the end of execution path.";
   }
   return nullptr;
 }
@@ -167,8 +167,8 @@ absl::StatusOr<cel::Handle<cel::Value>> ExecutionFrame::Evaluate(
     }
 
     if (value_stack().empty()) {
-      LOG(ERROR) << "Stack is empty after a ExpressionStep.Evaluate. "
-                    "Try to disable short-circuiting.";
+      ABSL_LOG(ERROR) << "Stack is empty after a ExpressionStep.Evaluate. "
+                         "Try to disable short-circuiting.";
       continue;
     }
     CEL_RETURN_IF_ERROR(

--- a/eval/eval/evaluator_stack.h
+++ b/eval/eval/evaluator_stack.h
@@ -46,8 +46,8 @@ class EvaluatorStack {
   // Please note that calls to Push may invalidate returned Span object.
   absl::Span<const cel::Handle<cel::Value>> GetSpan(size_t size) const {
     if (!HasEnough(size)) {
-      LOG(ERROR) << "Requested span size (" << size
-                 << ") exceeds current stack size: " << current_size_;
+      ABSL_LOG(ERROR) << "Requested span size (" << size
+                      << ") exceeds current stack size: " << current_size_;
     }
     return absl::Span<const cel::Handle<cel::Value>>(
         stack_.data() + current_size_ - size, size);
@@ -65,7 +65,7 @@ class EvaluatorStack {
   // Checking that stack is not empty is caller's responsibility.
   const cel::Handle<cel::Value>& Peek() const {
     if (empty()) {
-      LOG(ERROR) << "Peeking on empty EvaluatorStack";
+      ABSL_LOG(ERROR) << "Peeking on empty EvaluatorStack";
     }
     return stack_[current_size_ - 1];
   }
@@ -74,7 +74,7 @@ class EvaluatorStack {
   // Checking that stack is not empty is caller's responsibility.
   const AttributeTrail& PeekAttribute() const {
     if (empty()) {
-      LOG(ERROR) << "Peeking on empty EvaluatorStack";
+      ABSL_LOG(ERROR) << "Peeking on empty EvaluatorStack";
     }
     return attribute_stack_[current_size_ - 1];
   }
@@ -83,8 +83,8 @@ class EvaluatorStack {
   // Checking that stack has enough elements is caller's responsibility.
   void Pop(size_t size) {
     if (!HasEnough(size)) {
-      LOG(ERROR) << "Trying to pop more elements (" << size
-                 << ") than the current stack size: " << current_size_;
+      ABSL_LOG(ERROR) << "Trying to pop more elements (" << size
+                      << ") than the current stack size: " << current_size_;
     }
     while (size > 0) {
       stack_.pop_back();
@@ -101,7 +101,7 @@ class EvaluatorStack {
 
   void Push(cel::Handle<cel::Value> value, AttributeTrail attribute) {
     if (current_size_ >= max_size()) {
-      LOG(ERROR) << "No room to push more elements on to EvaluatorStack";
+      ABSL_LOG(ERROR) << "No room to push more elements on to EvaluatorStack";
     }
     stack_.push_back(std::move(value));
     attribute_stack_.push_back(std::move(attribute));
@@ -118,7 +118,7 @@ class EvaluatorStack {
   // Checking that stack is not empty is caller's responsibility.
   void PopAndPush(cel::Handle<cel::Value> value, AttributeTrail attribute) {
     if (empty()) {
-      LOG(ERROR) << "Cannot PopAndPush on empty stack.";
+      ABSL_LOG(ERROR) << "Cannot PopAndPush on empty stack.";
     }
     stack_[current_size_ - 1] = std::move(value);
     attribute_stack_[current_size_ - 1] = std::move(attribute);

--- a/eval/eval/select_step.cc
+++ b/eval/eval/select_step.cc
@@ -116,7 +116,7 @@ absl::optional<Handle<Value>> CheckForMarkedAttributes(
     }
     // Invariant broken (an invalid CEL Attribute shouldn't match anything).
     // Log and return a CelError.
-    LOG(ERROR)
+    ABSL_LOG(ERROR)
         << "Invalid attribute pattern matched select path: "
         << attribute_string.status().ToString();  // NOLINT: OSS compatibility
     return CreateErrorValueFromView(Arena::Create<absl::Status>(

--- a/eval/internal/BUILD
+++ b/eval/internal/BUILD
@@ -35,7 +35,6 @@ cc_library(
         "//internal:status_macros",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",

--- a/eval/internal/interop.cc
+++ b/eval/internal/interop.cc
@@ -21,7 +21,6 @@
 #include "google/protobuf/arena.h"
 #include "absl/base/attributes.h"
 #include "absl/container/flat_hash_map.h"
-#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"

--- a/eval/public/BUILD
+++ b/eval/public/BUILD
@@ -83,7 +83,7 @@ cc_library(
         "//internal:status_macros",
         "//internal:utf8",
         "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -633,7 +633,7 @@ cc_library(
     deps = [
         ":ast_visitor",
         ":source_position",
-        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/types:variant",
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
     ],
@@ -651,7 +651,7 @@ cc_library(
         ":ast_visitor_native",
         ":source_position_native",
         "//base:ast_internal",
-        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/types:variant",
     ],
 )
@@ -835,7 +835,7 @@ cc_library(
     deps = [
         ":ast_visitor",
         ":source_position",
-        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/types:variant",
         "@com_google_googleapis//google/api/expr/v1alpha1:syntax_cc_proto",
@@ -870,7 +870,7 @@ cc_library(
     deps = [
         ":ast_visitor_native",
         ":source_position_native",
-        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/types:span",
         "@com_google_absl//absl/types:variant",
     ],

--- a/eval/public/ast_rewrite.cc
+++ b/eval/public/ast_rewrite.cc
@@ -18,7 +18,7 @@
 #include <vector>
 
 #include "google/api/expr/v1alpha1/syntax.pb.h"
-#include "absl/log/log.h"
+#include "absl/log/absl_log.h"
 #include "absl/types/variant.h"
 #include "eval/public/ast_visitor.h"
 #include "eval/public/source_position.h"
@@ -196,7 +196,7 @@ struct PostVisitor {
       case Expr::EXPR_KIND_NOT_SET:
         break;
       default:
-        LOG(ERROR) << "Unsupported Expr kind: " << expr->expr_kind_case();
+        ABSL_LOG(ERROR) << "Unsupported Expr kind: " << expr->expr_kind_case();
     }
 
     visitor->PostVisitExpr(expr, &position);

--- a/eval/public/ast_rewrite_native.cc
+++ b/eval/public/ast_rewrite_native.cc
@@ -17,7 +17,7 @@
 #include <stack>
 #include <vector>
 
-#include "absl/log/log.h"
+#include "absl/log/absl_log.h"
 #include "absl/types/variant.h"
 #include "eval/public/ast_visitor_native.h"
 #include "eval/public/source_position_native.h"
@@ -199,7 +199,7 @@ struct PostVisitor {
         visitor->PostVisitComprehension(&comprehension, expr, position);
       }
       void operator()(absl::monostate) {
-        LOG(ERROR) << "Unsupported Expr kind";
+        ABSL_LOG(ERROR) << "Unsupported Expr kind";
       }
     } handler{visitor, record.expr, &position};
     absl::visit(handler, record.expr->expr_kind());

--- a/eval/public/ast_traverse.cc
+++ b/eval/public/ast_traverse.cc
@@ -17,7 +17,7 @@
 #include <stack>
 
 #include "google/api/expr/v1alpha1/syntax.pb.h"
-#include "absl/log/log.h"
+#include "absl/log/absl_log.h"
 #include "absl/types/variant.h"
 #include "eval/public/ast_visitor.h"
 #include "eval/public/source_position.h"
@@ -197,7 +197,7 @@ struct PostVisitor {
                                         &position);
         break;
       default:
-        LOG(ERROR) << "Unsupported Expr kind: " << expr->expr_kind_case();
+        ABSL_LOG(ERROR) << "Unsupported Expr kind: " << expr->expr_kind_case();
     }
 
     visitor->PostVisitExpr(expr, &position);

--- a/eval/public/ast_traverse_native.cc
+++ b/eval/public/ast_traverse_native.cc
@@ -16,7 +16,7 @@
 
 #include <stack>
 
-#include "absl/log/log.h"
+#include "absl/log/absl_log.h"
 #include "absl/types/variant.h"
 #include "base/ast_internal.h"
 #include "eval/public/ast_visitor_native.h"
@@ -174,7 +174,7 @@ struct PostVisitor {
                                         &position);
       }
       void operator()(absl::monostate) {
-        LOG(ERROR) << "Unsupported Expr kind";
+        ABSL_LOG(ERROR) << "Unsupported Expr kind";
       }
     } handler{visitor, record.expr,
               SourcePosition(expr->id(), record.source_info)};

--- a/eval/public/builtin_func_test.cc
+++ b/eval/public/builtin_func_test.cc
@@ -69,7 +69,7 @@ class BuiltinsTest : public ::testing::Test {
     Expr expr;
     SourceInfo source_info;
     auto call = expr.mutable_call_expr();
-    call->set_function(operation.data(), operation.size());
+    call->set_function(operation);
 
     if (target.has_value()) {
       std::string param_name = "target";

--- a/eval/public/cel_expr_builder_factory.cc
+++ b/eval/public/cel_expr_builder_factory.cc
@@ -39,13 +39,13 @@ std::unique_ptr<CelExpressionBuilder> CreateCelExpressionBuilder(
     google::protobuf::MessageFactory* message_factory,
     const InterpreterOptions& options) {
   if (descriptor_pool == nullptr) {
-    LOG(ERROR) << "Cannot pass nullptr as descriptor pool to "
-                  "CreateCelExpressionBuilder";
+    ABSL_LOG(ERROR) << "Cannot pass nullptr as descriptor pool to "
+                       "CreateCelExpressionBuilder";
     return nullptr;
   }
   if (auto s = ValidateStandardMessageTypes(*descriptor_pool); !s.ok()) {
-    LOG(WARNING) << "Failed to validate standard message types: "
-                 << s.ToString();  // NOLINT: OSS compatibility
+    ABSL_LOG(WARNING) << "Failed to validate standard message types: "
+                      << s.ToString();  // NOLINT: OSS compatibility
     return nullptr;
   }
 

--- a/eval/public/cel_value.h
+++ b/eval/public/cel_value.h
@@ -25,7 +25,7 @@
 #include "absl/base/attributes.h"
 #include "absl/base/macros.h"
 #include "absl/base/optimization.h"
-#include "absl/log/log.h"
+#include "absl/log/absl_log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -489,7 +489,8 @@ class CelValue {
 
   // Crashes with a null pointer error.
   static void CrashNullPointer(Type type) ABSL_ATTRIBUTE_COLD {
-    LOG(FATAL) << "Null pointer supplied for " << TypeName(type);  // Crash ok
+    ABSL_LOG(FATAL) << "Null pointer supplied for "
+                    << TypeName(type);  // Crash ok
   }
 
   // Null pointer checker for pointer-based types.
@@ -502,9 +503,9 @@ class CelValue {
   // Crashes with a type mismatch error.
   static void CrashTypeMismatch(Type requested_type,
                                 Type actual_type) ABSL_ATTRIBUTE_COLD {
-    LOG(FATAL) << "Type mismatch"                             // Crash ok
-               << ": expected " << TypeName(requested_type)   // Crash ok
-               << ", encountered " << TypeName(actual_type);  // Crash ok
+    ABSL_LOG(FATAL) << "Type mismatch"                             // Crash ok
+                    << ": expected " << TypeName(requested_type)   // Crash ok
+                    << ", encountered " << TypeName(actual_type);  // Crash ok
   }
 
   // Gets value of type specified

--- a/eval/public/portable_cel_expr_builder_factory.cc
+++ b/eval/public/portable_cel_expr_builder_factory.cc
@@ -34,8 +34,8 @@ std::unique_ptr<CelExpressionBuilder> CreatePortableExprBuilder(
     std::unique_ptr<LegacyTypeProvider> type_provider,
     const InterpreterOptions& options) {
   if (type_provider == nullptr) {
-    LOG(ERROR) << "Cannot pass nullptr as type_provider to "
-                  "CreatePortableExprBuilder";
+    ABSL_LOG(ERROR) << "Cannot pass nullptr as type_provider to "
+                       "CreatePortableExprBuilder";
     return nullptr;
   }
   cel::RuntimeOptions runtime_options = ConvertToRuntimeOptions(options);

--- a/eval/public/structs/cel_proto_lite_wrap_util.cc
+++ b/eval/public/structs/cel_proto_lite_wrap_util.cc
@@ -698,7 +698,7 @@ absl::StatusOr<BytesValue*> CreateMessageFromValue(
   if (wrapper == nullptr) {
     wrapper = google::protobuf::Arena::CreateMessage<BytesValue>(arena);
   }
-  wrapper->set_value(view_val.value().data(), view_val.value().size());
+  wrapper->set_value(view_val.value());
   return wrapper;
 }
 
@@ -782,7 +782,7 @@ absl::StatusOr<StringValue*> CreateMessageFromValue(
   if (wrapper == nullptr) {
     wrapper = google::protobuf::Arena::CreateMessage<StringValue>(arena);
   }
-  wrapper->set_value(view_val.value().data(), view_val.value().size());
+  wrapper->set_value(view_val.value());
   return wrapper;
 }
 
@@ -950,7 +950,7 @@ absl::StatusOr<Value*> CreateMessageFromValue(
     case CelValue::Type::kString: {
       CelValue::StringHolder val;
       if (cel_value.GetValue(&val)) {
-        wrapper->set_string_value(val.value().data(), val.value().size());
+        wrapper->set_string_value(val.value());
       }
     } break;
     case CelValue::Type::kTimestamp: {

--- a/eval/public/structs/cel_proto_wrap_util.cc
+++ b/eval/public/structs/cel_proto_wrap_util.cc
@@ -468,7 +468,7 @@ google::protobuf::Message* MessageFromValue(
   if (!value.GetValue(&view_val)) {
     return nullptr;
   }
-  wrapper->set_value(view_val.value().data(), view_val.value().size());
+  wrapper->set_value(view_val.value());
   return wrapper;
 }
 
@@ -536,7 +536,7 @@ google::protobuf::Message* MessageFromValue(
   if (!value.GetValue(&view_val)) {
     return nullptr;
   }
-  wrapper->set_value(view_val.value().data(), view_val.value().size());
+  wrapper->set_value(view_val.value());
   return wrapper;
 }
 
@@ -682,7 +682,7 @@ google::protobuf::Message* MessageFromValue(const CelValue& value, Value* json,
     case CelValue::Type::kString: {
       CelValue::StringHolder val;
       if (value.GetValue(&val)) {
-        json->set_string_value(val.value().data(), val.value().size());
+        json->set_string_value(val.value());
         return json;
       }
     } break;

--- a/eval/public/structs/field_access_impl.cc
+++ b/eval/public/structs/field_access_impl.cc
@@ -599,7 +599,7 @@ class ScalarFieldSetter : public FieldSetter<ScalarFieldSetter> {
 
   bool SetMessage(const Message* value) const {
     if (!value) {
-      LOG(ERROR) << "Message is NULL";
+      ABSL_LOG(ERROR) << "Message is NULL";
       return true;
     }
     if (value->GetDescriptor()->full_name() ==

--- a/eval/public/structs/field_access_impl_test.cc
+++ b/eval/public/structs/field_access_impl_test.cc
@@ -184,14 +184,14 @@ class SingleFieldTest : public testing::TestWithParam<AccessFieldTestParam> {
 TEST_P(SingleFieldTest, Getter) {
   TestAllTypes test_message;
   ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(std::string(message_textproto()), &test_message));
+      google::protobuf::TextFormat::ParseFromString(message_textproto(), &test_message));
   google::protobuf::Arena arena;
 
   ASSERT_OK_AND_ASSIGN(
       CelValue accessed_value,
       CreateValueFromSingleField(
           &test_message,
-          test_message.GetDescriptor()->FindFieldByName(std::string(field_name())),
+          test_message.GetDescriptor()->FindFieldByName(field_name()),
           ProtoWrapperTypeOptions::kUnsetProtoDefault,
           &CelProtoWrapper::InternalWrapMessage, &arena));
 
@@ -204,7 +204,7 @@ TEST_P(SingleFieldTest, Setter) {
   google::protobuf::Arena arena;
 
   ASSERT_OK(SetValueToSingleField(
-      to_set, test_message.GetDescriptor()->FindFieldByName(std::string(field_name())),
+      to_set, test_message.GetDescriptor()->FindFieldByName(field_name()),
       &test_message, &arena));
 
   EXPECT_THAT(test_message, EqualsProto(message_textproto()));
@@ -361,14 +361,14 @@ class RepeatedFieldTest : public testing::TestWithParam<AccessFieldTestParam> {
 TEST_P(RepeatedFieldTest, GetFirstElem) {
   TestAllTypes test_message;
   ASSERT_TRUE(
-      google::protobuf::TextFormat::ParseFromString(std::string(message_textproto()), &test_message));
+      google::protobuf::TextFormat::ParseFromString(message_textproto(), &test_message));
   google::protobuf::Arena arena;
 
   ASSERT_OK_AND_ASSIGN(
       CelValue accessed_value,
       CreateValueFromRepeatedField(
           &test_message,
-          test_message.GetDescriptor()->FindFieldByName(std::string(field_name())), 0,
+          test_message.GetDescriptor()->FindFieldByName(field_name()), 0,
           &CelProtoWrapper::InternalWrapMessage, &arena));
 
   EXPECT_THAT(accessed_value, test::EqualsCelValue(cel_value()));
@@ -380,7 +380,7 @@ TEST_P(RepeatedFieldTest, AppendElem) {
   google::protobuf::Arena arena;
 
   ASSERT_OK(AddValueToRepeatedField(
-      to_add, test_message.GetDescriptor()->FindFieldByName(std::string(field_name())),
+      to_add, test_message.GetDescriptor()->FindFieldByName(field_name()),
       &test_message, &arena));
 
   EXPECT_THAT(test_message, EqualsProto(message_textproto()));

--- a/eval/public/structs/legacy_type_provider.h
+++ b/eval/public/structs/legacy_type_provider.h
@@ -46,7 +46,7 @@ class LegacyTypeProvider : public cel::TypeProvider {
   // created ones, the TypeInfoApis returned from this method should be the same
   // as the ones used in value creation.
   virtual absl::optional<const LegacyTypeInfoApis*> ProvideLegacyTypeInfo(
-      absl::string_view name) const {
+      ABSL_ATTRIBUTE_UNUSED absl::string_view name) const {
     return absl::nullopt;
   }
 
@@ -61,7 +61,8 @@ class LegacyTypeProvider : public cel::TypeProvider {
   // TODO(issues/5): Move protobuf-Any API from top level
   // [Legacy]TypeProviders.
   virtual absl::optional<const LegacyAnyPackingApis*>
-  ProvideLegacyAnyPackingApis(absl::string_view name) const {
+  ProvideLegacyAnyPackingApis(
+      ABSL_ATTRIBUTE_UNUSED absl::string_view name) const {
     return absl::nullopt;
   }
 };

--- a/eval/public/structs/proto_message_type_adapter.cc
+++ b/eval/public/structs/proto_message_type_adapter.cc
@@ -86,7 +86,7 @@ absl::StatusOr<bool> HasFieldImpl(const google::protobuf::Message* message,
                                   absl::string_view field_name) {
   ABSL_ASSERT(descriptor == message->GetDescriptor());
   const Reflection* reflection = message->GetReflection();
-  const FieldDescriptor* field_desc = descriptor->FindFieldByName(std::string(field_name));
+  const FieldDescriptor* field_desc = descriptor->FindFieldByName(field_name);
   if (field_desc == nullptr && reflection != nullptr) {
     // Search to see whether the field name is referring to an extension.
     field_desc = reflection->FindKnownExtensionByName(field_name);
@@ -122,7 +122,7 @@ absl::StatusOr<CelValue> GetFieldImpl(const google::protobuf::Message* message,
                                       cel::MemoryManager& memory_manager) {
   ABSL_ASSERT(descriptor == message->GetDescriptor());
   const Reflection* reflection = message->GetReflection();
-  const FieldDescriptor* field_desc = descriptor->FindFieldByName(std::string(field_name));
+  const FieldDescriptor* field_desc = descriptor->FindFieldByName(field_name);
   if (field_desc == nullptr && reflection != nullptr) {
     std::string ext_name(field_name);
     field_desc = reflection->FindKnownExtensionByName(ext_name);
@@ -332,7 +332,7 @@ ProtoMessageTypeAdapter::NewInstance(cel::MemoryManager& memory_manager) const {
 }
 
 bool ProtoMessageTypeAdapter::DefinesField(absl::string_view field_name) const {
-  return descriptor_->FindFieldByName(std::string(field_name)) != nullptr;
+  return descriptor_->FindFieldByName(field_name) != nullptr;
 }
 
 absl::StatusOr<bool> ProtoMessageTypeAdapter::HasField(
@@ -365,7 +365,7 @@ absl::Status ProtoMessageTypeAdapter::SetField(
                        UnwrapMessage(instance, "SetField"));
 
   const google::protobuf::FieldDescriptor* field_descriptor =
-      descriptor_->FindFieldByName(std::string(field_name));
+      descriptor_->FindFieldByName(field_name);
   CEL_RETURN_IF_ERROR(
       ValidateSetFieldOp(field_descriptor != nullptr, field_name, "not found"));
 

--- a/eval/public/structs/protobuf_descriptor_type_provider.cc
+++ b/eval/public/structs/protobuf_descriptor_type_provider.cc
@@ -53,7 +53,7 @@ ProtobufDescriptorProvider::ProvideLegacyTypeInfo(
 std::unique_ptr<ProtoMessageTypeAdapter> ProtobufDescriptorProvider::GetType(
     absl::string_view name) const {
   const google::protobuf::Descriptor* descriptor =
-      descriptor_pool_->FindMessageTypeByName(std::string(name));
+      descriptor_pool_->FindMessageTypeByName(name);
   if (descriptor == nullptr) {
     return nullptr;
   }

--- a/extensions/protobuf/type_provider.cc
+++ b/extensions/protobuf/type_provider.cc
@@ -23,7 +23,7 @@ namespace cel::extensions {
 absl::StatusOr<absl::optional<Handle<Type>>> ProtoTypeProvider::ProvideType(
     TypeFactory& type_factory, absl::string_view name) const {
   {
-    const auto* desc = pool_->FindMessageTypeByName(std::string(name));
+    const auto* desc = pool_->FindMessageTypeByName(name);
     if (desc != nullptr) {
       return type_factory.CreateStructType<ProtoStructType>(desc, factory_);
     }


### PR DESCRIPTION
Use ABSL_LOG macros over LOG macros
LOG causes macro pollution and conflicts with ProxyWasm SDK (see https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/issues/154).
