### PR TITLE
Support accessing fields by name

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,4 +15,6 @@ build:asan --copt -O1
 build:asan --copt -fno-optimize-sibling-calls
 build:asan --linkopt=-fuse-ld=lld
 
-
+try-import %workspace%/clang.bazelrc
+try-import %workspace%/user.bazelrc
+try-import %workspace%/local_tsan.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ bazel-out
 bazel-testlogs
 bazel-cel-cpp
 *~
+clang.bazelrc
+user.bazelrc
+local_tsan.bazelrc

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bazel-cel-cpp
 clang.bazelrc
 user.bazelrc
 local_tsan.bazelrc
+.vscode

--- a/eval/eval/container_access_step_test.cc
+++ b/eval/eval/container_access_step_test.cc
@@ -329,6 +329,18 @@ TEST_F(ContainerAccessStepTest, TestMapUnknownKey) {
   ASSERT_TRUE(result.IsUnknownSet());
 }
 
+TEST_F(ContainerAccessStepTest, TestMessageKeyAccess) {
+  v1alpha1::Constant msg;
+  *msg.mutable_string_value() = "test";
+
+  CelValue result =
+      EvaluateAttribute(CelProtoWrapper::CreateMessage(&msg, &arena_),
+                        CelValue::CreateStringView("string_value"), true, true);
+  ASSERT_TRUE(result.IsString()) << result.DebugString();
+  EXPECT_EQ(result.StringOrDie().value(), "test");
+}
+
+
 TEST_F(ContainerAccessStepTest, TestUnknownContainer) {
   UnknownSet unknown_set;
   CelValue result = EvaluateAttribute(CelValue::CreateUnknownSet(&unknown_set),


### PR DESCRIPTION
Matching the cel-go impl. This is needed to work around field names that are also keywords, such as "in" which is used by protovalidate.