### PR TITLE
Fix: use of sized deallocation in base/memory.h wo check

### DIFF
--- a/base/memory.h
+++ b/base/memory.h
@@ -89,8 +89,14 @@ class Allocator {
 
   void deallocate(pointer p, size_type n) {
     if (!allocation_only_) {
-      ::operator delete(static_cast<void*>(p), n * sizeof(T),
+#if defined(__cpp_sized_deallocation) && __cpp_sized_deallocation >= 201309L
+      ::operator delete(static_cast<void *>(p), n * sizeof(T),
                         static_cast<std::align_val_t>(alignof(T)));
+#else
+      ::operator delete(static_cast<void *>(p),
+                        static_cast<std::align_val_t>(alignof(T)));
+      static_cast<void>(n); // unused
+#endif
     }
   }
 


### PR DESCRIPTION
Dependant projects that do not use `-fsized-deallocation` would not compile with the call to delete(void*, size_t, align).

There are other places that already check for
`defined(__cpp_sized_deallocation)` and this patch just shares this practice.

Testing:

    // fix .bazelrc to have:
    build --cxxopt=-fno-sized-deallocation

    $ bazel build --verbose_failures //base:\*