### PR TITLE
Fix antlr4 parser generation on Windows

### DIFF
--- a/bazel/antlr.bzl
+++ b/bazel/antlr.bzl
@@ -42,13 +42,21 @@ def antlr_cc_library(name, src, package):
 def _antlr_library(ctx):
     output = ctx.actions.declare_directory(ctx.attr.name)
 
+    src_path = ctx.file.src.path
+
+    # Workaround for Antlr4 bug:
+    # https://github.com/antlr/antlr4/issues/3138
+    windows_constraint = ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]
+    if ctx.target_platform_has_constraint(windows_constraint):
+        src_path = src_path.replace('/', '\\')
+
     antlr_args = ctx.actions.args()
     antlr_args.add("-Dlanguage=Cpp")
     antlr_args.add("-no-listener")
     antlr_args.add("-visitor")
     antlr_args.add("-o", output.path)
     antlr_args.add("-package", ctx.attr.package)
-    antlr_args.add(ctx.file.src)
+    antlr_args.add(src_path)
 
     # Strip ".g4" extension.
     basename = ctx.file.src.basename[:-3]
@@ -98,5 +106,6 @@ antlr_library = rule(
             cfg = "exec",  # buildifier: disable=attr-cfg
             default = Label("//bazel:antlr4_tool"),
         ),
+        '_windows_constraint': attr.label(default = '@platforms//os:windows'),
     },
 )


### PR DESCRIPTION
Antlr4 has some unfortunate quirks on Windows, one of which being that if you use paths with forward solidi, it will determine the wrong output directory. This leads to files mysteriously missing during compilation.

This does not fix compilation on Windows entirely, but it should get closer.