### PR TITLE
Silence gcc overloaded-virtual warning in FieldBackedMapImpl

### DIFF
--- a/eval/public/containers/internal_field_backed_map_impl.h
+++ b/eval/public/containers/internal_field_backed_map_impl.h
@@ -43,6 +43,14 @@ class FieldBackedMapImpl : public CelMap {
   // Presence test function.
   absl::StatusOr<bool> Has(const CelValue& key) const override;
 
+  // This is here exclusively to silence gcc overloaded-virtual warning which,
+  // depending on the compilation options, can be converted to an error.
+  //
+  // As per https://gcc.gnu.org/onlinedocs/gcc-13.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Woverloaded-virtual
+  // you can silence this gcc warning by adding a using declaration for the
+  // "hidden" method.
+  using CelMap::ListKeys;
+
   absl::StatusOr<const CelList*> ListKeys() const override;
 
  protected:


### PR DESCRIPTION
gcc complains about FieldBackedMapImpl::ListKeys when overloaded-virtual check is enabled. When using -Werror, warnings like this are converted to errors breaking builds.

That's what happened to gcc build of Envoy a while back. The issue in Envoy was fixed by introducing a patch for cel-cpp that was applied to the source during Envoy build (see
https://github.com/envoyproxy/envoy/pull/31814).

Unfortunately during cel-cpp version update in Envoy instead of updating the patch, dropping the parts that are not needed anymore, we dropped the whole cep-cpp patch all together in
https://github.com/envoyproxy/envoy/pull/36661. And now gcc can't build Envoy again.

This change makes the change to silence the gcc warning in the cel-cpp codebase, which hopefully will be a bit more durable than maintaing a patch on the Envoy side.

The change is not very invasive (just a using declaration), plus I can see at least another place in the code that does the same to deal with gcc warning (see https://github.com/google/cel-cpp/blob/61d0334e263008403a50859afa71bb05bf519c97/tools/flatbuffers_backed_impl.h#L27-L28). With that in mind, would you be open to include this change in the cel-cpp upstream repository?

Thank you.