### PR TITLE
Fix build of cel-cpp with newer clang versions

### DIFF
--- a/common/json.h
+++ b/common/json.h
@@ -123,17 +123,17 @@ class JsonArrayBuilder {
   JsonArrayBuilder& operator=(const JsonArrayBuilder&) = delete;
   JsonArrayBuilder& operator=(JsonArrayBuilder&&) = default;
 
-  bool empty() const { return impl_.get().empty(); }
+  bool empty() const;
 
   size_type size() const;
 
   iterator begin();
 
-  const_iterator begin() const { return impl_.get().begin(); }
+  const_iterator begin() const;
 
   iterator end();
 
-  const_iterator end() const { return impl_.get().end(); }
+  const_iterator end() const;
 
   reverse_iterator rbegin();
 
@@ -186,17 +186,17 @@ class ABSL_ATTRIBUTE_TRIVIAL_ABI JsonArray final {
   JsonArray& operator=(const JsonArray&) = default;
   JsonArray& operator=(JsonArray&&) = default;
 
-  bool empty() const { return impl_.get().empty(); }
+  bool empty() const;
 
   size_type size() const;
 
-  const_iterator begin() const { return impl_.get().begin(); }
+  const_iterator begin() const;
 
-  const_iterator cbegin() const { return impl_.get().cbegin(); }
+  const_iterator cbegin() const;
 
-  const_iterator end() const { return impl_.get().end(); }
+  const_iterator end() const;
 
-  const_iterator cend() const { return impl_.get().cend(); }
+  const_iterator cend() const;
 
   const_reverse_iterator rbegin() const;
 
@@ -222,12 +222,7 @@ class ABSL_ATTRIBUTE_TRIVIAL_ABI JsonArray final {
 
   static internal::CopyOnWrite<Container> Empty();
 
-  explicit JsonArray(internal::CopyOnWrite<Container> impl)
-      : impl_(std::move(impl)) {
-    if (impl_.get().empty()) {
-      impl_ = Empty();
-    }
-  }
+  explicit JsonArray(internal::CopyOnWrite<Container> impl);
 
   internal::CopyOnWrite<Container> impl_;
 };
@@ -483,12 +478,25 @@ inline void JsonObjectBuilder::insert(std::initializer_list<value_type> il) {
   impl_.mutable_get().insert(il);
 }
 
+inline bool JsonArrayBuilder::empty() const {
+    return impl_.get().empty();
+}
+
 inline JsonArrayBuilder::size_type JsonArrayBuilder::size() const {
   return impl_.get().size();
 }
 
+inline JsonArrayBuilder::const_iterator JsonArrayBuilder::begin() const {
+    return impl_.get().begin();
+}
+
+
 inline JsonArrayBuilder::iterator JsonArrayBuilder::begin() {
   return impl_.mutable_get().begin();
+}
+
+inline JsonArrayBuilder::const_iterator JsonArrayBuilder::end() const {
+    return impl_.get().end();
 }
 
 inline JsonArrayBuilder::iterator JsonArrayBuilder::end() {
@@ -542,8 +550,28 @@ inline JsonObjectBuilder::operator JsonObject() && {
   return std::move(*this).Build();
 }
 
+inline bool JsonArray::empty() const {
+    return impl_.get().empty();
+}
+
 inline JsonArray::size_type JsonArray::size() const {
   return impl_.get().size();
+}
+
+inline JsonArray::const_iterator JsonArray::begin() const {
+    return impl_.get().begin();
+}
+
+inline JsonArray::const_iterator JsonArray::cbegin() const {
+    return impl_.get().cbegin();
+}
+
+inline JsonArray::const_iterator JsonArray::end() const {
+    return impl_.get().end();
+}
+
+inline JsonArray::const_iterator JsonArray::cend() const {
+    return impl_.get().cend();
 }
 
 inline JsonArray::const_reverse_iterator JsonArray::rbegin() const {
@@ -568,6 +596,13 @@ inline JsonArray::const_reference JsonArray::at(size_type index) const {
 
 inline JsonArray::const_reference JsonArray::operator[](size_type index) const {
   return (impl_.get())[index];
+}
+
+inline JsonArray::JsonArray(internal::CopyOnWrite<Container> impl)
+    : impl_(std::move(impl)) {
+  if (impl_.get().empty()) {
+    impl_ = Empty();
+  }
 }
 
 inline bool operator==(const JsonArray& lhs, const JsonArray& rhs) {


### PR DESCRIPTION
Specifically I'm using clang-18 and with it I get a few errors like this coming from json.h:

```
In file included from external/com_google_cel_cpp/runtime/standard/comparison_functions.cc:15:
In file included from external/com_google_cel_cpp/runtime/standard/comparison_functions.h:18:
In file included from external/com_google_absl/absl/status/status.h:56:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/ostream:40:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/ios:41:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/exception:164:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/bits/exception_ptr.h:41:
In file included from /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/bits/move.h:37:
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/type_traits:1326:23: error: incomplete type 'cel::JsonObject' used in type trait expression
 1326 |                     __bool_constant<__has_trivial_destructor(_Tp)>>::type
      |                                     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/type_traits:3297:5: note: in instantiation of template class 'std::is_trivially_destructible<cel::JsonObject>' requested here
 3297 |     is_trivially_destructible<_Tp>::value;
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/variant:340:5: note: in instantiation of variable template specialization 'std::is_trivially_destructible_v<cel::JsonObject>' requested here
  340 |           (is_trivially_destructible_v<_Types> && ...);
      |            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/variant:349:4: note: in instantiation of static data member 'std::__detail::__variant::_Traits<cel::JsonNull, bool, double, absl::Cord, cel::JsonArray, cel::JsonObject>::_S_trivial_dtor' requested here
  349 |           _S_trivial_dtor && _S_trivial_move_ctor
      |           ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/variant:731:45: note: in instantiation of static data member 'std::__detail::__variant::_Traits<cel::JsonNull, bool, double, absl::Cord, cel::JsonArray, cel::JsonObject>::_S_trivial_move_assign' requested here
  731 |       _Move_assign_base<_Traits<_Types...>::_S_trivial_move_assign, _Types...>;
      |                                             ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/variant:734:28: note: in instantiation of template type alias '_Move_assign_alias' requested here
  734 |     struct _Variant_base : _Move_assign_alias<_Types...>
      |                            ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/variant:1338:15: note: in instantiation of template class 'std::__detail::__variant::_Variant_base<cel::JsonNull, bool, double, absl::Cord, cel::JsonArray, cel::JsonObject>' requested here
 1338 |     : private __detail::__variant::_Variant_base<_Types...>,
      |               ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.0/../../../../include/c++/13.2.0/bits/stl_vector.h:1086:24: note: in instantiation of template class 'std::variant<cel::JsonNull, bool, double, absl::Cord, cel::JsonArray, cel::JsonObject>' requested here
 1086 |       { return begin() == end(); }
      |                        ^
external/com_google_cel_cpp/common/json.h:126:43: note: in instantiation of member function 'std::vector<std::variant<cel::JsonNull, bool, double, absl::Cord, cel::JsonArray, cel::JsonObject>>::empty' requested here
  126 |   bool empty() const { return impl_.get().empty(); }
      |                                           ^
external/com_google_cel_cpp/common/json.h:73:34: note: forward declaration of 'cel::JsonObject'
   73 | class ABSL_ATTRIBUTE_TRIVIAL_ABI JsonObject;
```

This is just an example, there are more errors, but all of them are similar to each other. And all of them have the same root cause. Basically there is a circular dependencies between Json, JsonArray and JsonObject types. This circular dependency by itsels if not a problem (and certainly wasn't the problem before with older versions of clang and standard libraries, libstdc++ in our case) and is dealt with in the code by making forward declarations of the classes when necessary.

However, apparently now somewhere deep in the implementation of std::variant we have calls to C++ type traits that require a fully defined types (specifically in the error above is_trivially_destructible requires a fully defined type). So when compiler is forced to instantiate parts of std::variant template that refer to type traits, it results in a compilation error if at that point in time compiler only saw a forward declration of the type and not the complete defintiion.

NOTE: It's not a mistake that type traits require a fully defined type - C++ standard is pretty clear on that point; what is not clear is why those type traits calls were added in the first place.

The problem shown above arieses specifically when compiler sees a definiontion of JsonArray::empty method that calls std::vector<std::variant>::empty which forces C++ compiler to instantiate the type and results in an error.

The solutions is rather simple and non-invasive - move the defitnions of the methods out of the class to the point where all the class definitions are already available to the compiler. I can also see it being done for at least some of the methods already, so it should not be that big of a deal to move a few other methods outside of the class as well.

Plus, I would imagine sooner or later cel C++ implementation will need to support newer versions of clang compiler, so hopefully this change will not be terribly disruptive and align with inevitable future of supporting newer compiler versions.