### PR TITLE
Remove unnecessary dependency on cel_proto_wrap_util

### DIFF
--- a/eval/public/structs/BUILD
+++ b/eval/public/structs/BUILD
@@ -57,7 +57,6 @@ cc_library(
     deps = [
         ":protobuf_value_factory",
         "//eval/public:cel_value",
-        "//eval/testutil:test_message_cc_proto",
         "//internal:overflow",
         "//internal:proto_time_encoding",
         "//internal:status_macros",

--- a/eval/public/structs/cel_proto_wrap_util.cc
+++ b/eval/public/structs/cel_proto_wrap_util.cc
@@ -43,7 +43,6 @@
 #include "absl/types/variant.h"
 #include "eval/public/cel_value.h"
 #include "eval/public/structs/protobuf_value_factory.h"
-#include "eval/testutil/test_message.pb.h"
 #include "internal/overflow.h"
 #include "internal/proto_time_encoding.h"
 #include "internal/status_macros.h"


### PR DESCRIPTION
For some reason, cel_proto_wrap_util `#include`s "eval/testutil/test_message.pb.h" even though I don't think it is used anywhere. This results in an otherwise unnecessary dependency on the test protos in a non-test target.