### PR TITLE
cel_cc_embed: Open in file in binary mode

### DIFF
--- a/bazel/cel_cc_embed.cc
+++ b/bazel/cel_cc_embed.cc
@@ -34,7 +34,7 @@ namespace {
 
 std::vector<uint8_t> ReadFile(const std::string& path) {
   ABSL_CHECK(!path.empty()) << "--in is required";
-  std::ifstream file(path);
+  std::ifstream file(path, std::ifstream::binary);
   ABSL_CHECK(file.is_open()) << path;
   file.seekg(0, file.end);
   ABSL_CHECK(file.good());


### PR DESCRIPTION
This is necessary on Windows; otherwise, newline conversion will corrupt the result.

Related issue: #768