### PR TITLE
Avoid including time_util in time.h

### DIFF
--- a/internal/time.cc
+++ b/internal/time.cc
@@ -24,6 +24,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "internal/status_macros.h"
+#include "google/protobuf/util/time_util.h"
 
 namespace cel::internal {
 
@@ -35,6 +36,38 @@ std::string RawFormatTimestamp(absl::Time timestamp) {
 }
 
 }  // namespace
+
+absl::Duration MaxDuration() {
+  // This currently supports a larger range then the current CEL spec. The
+  // intent is to widen the CEL spec to support the larger range and match
+  // google.protobuf.Duration from protocol buffer messages, which this
+  // implementation currently supports.
+  // TODO: revisit
+  return absl::Seconds(google::protobuf::util::TimeUtil::kDurationMaxSeconds) +
+         absl::Nanoseconds(google::protobuf::util::TimeUtil::kDurationMaxNanoseconds);
+}
+
+absl::Duration MinDuration() {
+  // This currently supports a larger range then the current CEL spec. The
+  // intent is to widen the CEL spec to support the larger range and match
+  // google.protobuf.Duration from protocol buffer messages, which this
+  // implementation currently supports.
+  // TODO: revisit
+  return absl::Seconds(google::protobuf::util::TimeUtil::kDurationMinSeconds) +
+         absl::Nanoseconds(google::protobuf::util::TimeUtil::kDurationMinNanoseconds);
+}
+
+absl::Time MaxTimestamp() {
+  return absl::UnixEpoch() +
+         absl::Seconds(google::protobuf::util::TimeUtil::kTimestampMaxSeconds) +
+         absl::Nanoseconds(google::protobuf::util::TimeUtil::kTimestampMaxNanoseconds);
+}
+
+absl::Time MinTimestamp() {
+  return absl::UnixEpoch() +
+         absl::Seconds(google::protobuf::util::TimeUtil::kTimestampMinSeconds) +
+         absl::Nanoseconds(google::protobuf::util::TimeUtil::kTimestampMinNanoseconds);
+}
 
 absl::Status ValidateDuration(absl::Duration duration) {
   if (duration < MinDuration()) {

--- a/internal/time.h
+++ b/internal/time.h
@@ -21,45 +21,16 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
-#include "google/protobuf/util/time_util.h"
 
 namespace cel::internal {
 
-    inline absl::Duration
-    MaxDuration() {
-  // This currently supports a larger range then the current CEL spec. The
-  // intent is to widen the CEL spec to support the larger range and match
-  // google.protobuf.Duration from protocol buffer messages, which this
-  // implementation currently supports.
-  // TODO: revisit
-  return absl::Seconds(google::protobuf::util::TimeUtil::kDurationMaxSeconds) +
-         absl::Nanoseconds(google::protobuf::util::TimeUtil::kDurationMaxNanoseconds);
-}
+absl::Duration MaxDuration();
 
-    inline absl::Duration
-    MinDuration() {
-  // This currently supports a larger range then the current CEL spec. The
-  // intent is to widen the CEL spec to support the larger range and match
-  // google.protobuf.Duration from protocol buffer messages, which this
-  // implementation currently supports.
-  // TODO: revisit
-  return absl::Seconds(google::protobuf::util::TimeUtil::kDurationMinSeconds) +
-         absl::Nanoseconds(google::protobuf::util::TimeUtil::kDurationMinNanoseconds);
-}
+absl::Duration MinDuration();
 
-    inline absl::Time
-    MaxTimestamp() {
-  return absl::UnixEpoch() +
-         absl::Seconds(google::protobuf::util::TimeUtil::kTimestampMaxSeconds) +
-         absl::Nanoseconds(google::protobuf::util::TimeUtil::kTimestampMaxNanoseconds);
-}
+absl::Time MaxTimestamp();
 
-    inline absl::Time
-    MinTimestamp() {
-  return absl::UnixEpoch() +
-         absl::Seconds(google::protobuf::util::TimeUtil::kTimestampMinSeconds) +
-         absl::Nanoseconds(google::protobuf::util::TimeUtil::kTimestampMinNanoseconds);
-}
+absl::Time MinTimestamp();
 
 absl::Status ValidateDuration(absl::Duration duration);
 


### PR DESCRIPTION
Unfortunately, due to https://github.com/protocolbuffers/protobuf/issues/21301, including time_util inside of a header will cause a lot of headaches on MSVC/Windows. While that can and should be resolved separately of this, in the interim there will be a lot of people using protobuf versions without a fix for this for the foreseeable future. This leaves us with only a couple of obvious options: either inline the constants, or move the function definitions into time.cc. I chose the latter since it doesn't seem like there is likely to be a substantial performance hit for this, as these are only used in a couple of locations that don't appear to be very hot paths.