### PR TITLE
Prefer ptrdiff_t over ssize_t

### DIFF
--- a/extensions/lists_functions.cc
+++ b/extensions/lists_functions.cc
@@ -209,7 +209,7 @@ absl::StatusOr<ListValue> ListRange(
     google::protobuf::Arena* ABSL_NONNULL arena) {
   auto builder = NewListValueBuilder(arena);
   builder->Reserve(end);
-  for (ssize_t i = 0; i < end; ++i) {
+  for (int64_t i = 0; i < end; ++i) {
     CEL_RETURN_IF_ERROR(builder->Add(IntValue(i)));
   }
   return std::move(*builder).Build();
@@ -222,7 +222,7 @@ absl::StatusOr<ListValue> ListReverse(
     google::protobuf::Arena* ABSL_NONNULL arena) {
   auto builder = NewListValueBuilder(arena);
   CEL_ASSIGN_OR_RETURN(size_t size, list.Size());
-  for (ssize_t i = size - 1; i >= 0; --i) {
+  for (ptrdiff_t i = size - 1; i >= 0; --i) {
     CEL_ASSIGN_OR_RETURN(Value value,
                          list.Get(i, descriptor_pool, message_factory, arena));
     CEL_RETURN_IF_ERROR(builder->Add(value));

--- a/parser/parser.cc
+++ b/parser/parser.cc
@@ -459,26 +459,26 @@ class CodePointStream final : public CharStream {
     index_++;
   }
 
-  size_t LA(ssize_t i) override {
+  size_t LA(ptrdiff_t i) override {
     if (ABSL_PREDICT_FALSE(i == 0)) {
       return 0;
     }
-    auto p = static_cast<ssize_t>(index_);
+    auto p = static_cast<ptrdiff_t>(index_);
     if (i < 0) {
       i++;
       if (p + i - 1 < 0) {
         return IntStream::EOF;
       }
     }
-    if (p + i - 1 >= static_cast<ssize_t>(size_)) {
+    if (p + i - 1 >= static_cast<ptrdiff_t>(size_)) {
       return IntStream::EOF;
     }
     return buffer_.at(static_cast<size_t>(p + i - 1));
   }
 
-  ssize_t mark() override { return -1; }
+  ptrdiff_t mark() override { return -1; }
 
-  void release(ssize_t marker) override {}
+  void release(ptrdiff_t marker) override {}
 
   size_t index() override { return index_; }
 


### PR DESCRIPTION
This resolves a portability issue for Windows/MSVC.

`ssize_t` is a POSIX-defined type, not a C or C++ standard. `ssize_t` is not as useful of a type as it initially seems, as it only actually guarantees a range of [-1, `SSIZE_MAX`], where `SSIZE_MAX` is at least `_POSIX_SSIZE_MAX` (32767).

`ptrdiff_t` is defined to be the type that results from taking the difference of two pointers. It is not guaranteed for it to be possible for all pointer differences to be represented as a `ptrdiff_t`; however, despite not theoretically having a much more stringent definition, it typically either meets or exceeds the utility of `ssize_t` on top of being a part of the C standard, thereby being usable outside of POSIX platforms. See, for example, this thread on the emacs-devel list:

https://lists.gnu.org/archive/html/emacs-devel/2014-10/msg00019.html

Therefore, I suggest adopting `ptrdiff_t` instead. For any of the obvious platforms, it should be exactly the same as `ssize_t` but more portable.

Neither `ssize_t` nor `ptrdiff_t` are guaranteed to have a superset of the range of `size_t`, so code that uses `ssize_t` OR `ptrdiff_t` to store `size_t` values should tread carefully; this is not safe and not guaranteed to work (e.g. loops that iterate backwards should probably be adjusted.)

One usage of `ssize_t` is replaced with `int64_t` instead since it is more appropriate in that circumstance.

Related issue: #768