### PR TITLE
internal/new: Don't pass alignment to Delete when `__cpp_aligned_new` isn't set

### DIFF
--- a/internal/new.cc
+++ b/internal/new.cc
@@ -107,7 +107,7 @@ void AlignedDelete(void* ptr, std::align_val_t alignment) noexcept {
   ::operator delete(ptr, alignment);
 #else
   if (static_cast<size_t>(alignment) <= kDefaultNewAlignment) {
-    Delete(ptr, size);
+    Delete(ptr);
   } else {
 #if defined(_MSC_VER)
     _aligned_free(ptr);


### PR DESCRIPTION
Building `internal/new` on a system where `__cpp_aligned_new` isn't set (i.e. Darwin) fails with

```
➜  cel-cpp-0.13.0 bazel build //internal:new --sandbox_debug
INFO: Analyzed target //internal:new (0 packages loaded, 2892 targets configured).
ERROR: /private/tmp/cel-cpp-0.13.0/internal/BUILD:44:11: Compiling internal/new.cc failed: (Exit 1): sandbox-exec failed: error executing CppCompile command
  (cd /private/var/tmp/_bazel_martin/f51b858526a01daed3ad3e4aaed921d1/sandbox/darwin-sandbox/103/execroot/_main && \
  exec env - \
    PATH=/Users/martin/Library/Caches/bazelisk/downloads/sha256/79e4d2401b1c969d2b57babd0c50b0ca61b719689d8b029c919525744f52872c/bin:/Users/martin/.sdkman/candidates/java/current/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/martin/.nix-profile/bin:/etc/profiles/per-user/martin/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
    PWD=/proc/self/cwd \
    TMPDIR=/var/folders/xq/0kq1jwf943z1kntx09dcxlvc0000gn/T/ \
  /usr/bin/sandbox-exec -f /private/var/tmp/_bazel_martin/f51b858526a01daed3ad3e4aaed921d1/sandbox/darwin-sandbox/103/sandbox.sb /var/tmp/_bazel_martin/install/5b64cfdb8a44c51dfff6cba1c4581101/process-wrapper '--timeout=0' '--kill_delay=15' '--stats=/private/var/tmp/_bazel_martin/f51b858526a01daed3ad3e4aaed921d1/sandbox/darwin-sandbox/103/stats.out' external/rules_cc~~cc_configure_extension~local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer '-std=c++17' '-frandom-seed=bazel-out/darwin_arm64-fastbuild/bin/internal/_objs/new/new.o' '-mmacosx-version-min=10.11' -MD -MF bazel-out/darwin_arm64-fastbuild/bin/internal/_objs/new/new.d -iquote . -iquote bazel-out/darwin_arm64-fastbuild/bin -iquote external/abseil-cpp~ -iquote bazel-out/darwin_arm64-fastbuild/bin/external/abseil-cpp~ -Wno-deprecated-declarations '-std=c++17' -fsized-deallocation -c internal/new.cc -o bazel-out/darwin_arm64-fastbuild/bin/internal/_objs/new/new.o -no-canonical-prefixes -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"')
internal/new.cc:71:15: warning: 'aligned_alloc' is only available on macOS 10.15 or newer [-Wunguarded-availability-new]
   71 |   void* ptr = std::aligned_alloc(static_cast<size_t>(alignment), size);
      |               ^~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/malloc/_malloc.h:65:35: note: 'aligned_alloc' has been marked as being introduced in macOS 10.15 here, but the deployment target is macOS 10.11.0
   65 | void * __sized_by_or_null(__size) aligned_alloc(size_t __alignment, size_t __size) __result_use_check __alloc_align(1) __alloc_size(2) _MALLOC_TYPED(malloc_type_aligned_alloc, 2) __OSX_AVAILABLE(10.15) __IOS_AVAILABLE(13.0) __TVOS_AVAILABLE(13.0) __WATCHOS_AVAILABLE(6.0);
      |                                   ^
internal/new.cc:71:15: note: enclose 'aligned_alloc' in a __builtin_available check to silence this warning
   71 |   void* ptr = std::aligned_alloc(static_cast<size_t>(alignment), size);
      |               ^~~~~~~~~~~~~~~~~~
   72 |   if (ABSL_PREDICT_FALSE(size != 0 && ptr == nullptr)) {
   73 |     ThrowStdBadAlloc();
   74 |   }
   75 |   return ptr;
      |
internal/new.cc:110:17: error: use of undeclared identifier 'size'
  110 |     Delete(ptr, size);
      |                 ^
1 warning and 1 error generated.
Target //internal:new failed to build
```

I'm not a cpp programmer, but it seems like a trivial bug, since `Delete` only takes `ptr` as an argument.