### PR TITLE
Add basic workflow for windows/bazel test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,8 @@ build:linux --copt=-Wno-deprecated-declarations
 # you will typically need to spell out the compiler for local dev
 # BAZEL_VC=<install directory>
 # BAZEL_VC_FULL_VERSION=14.44.3520
+# Some dependencies rely on bash so you will likely need msys2
+# BAZEL_SH=C:\msys64\usr\bin\bash.exe
 build:msvc --cxxopt="-std:c++20" --cxxopt="-utf-8" --host_cxxopt="-std:c++20"
 build:msvc --define=protobuf_allow_msvc=true
 build:msvc --test_tag_filters=-benchmark,-notap,-no_test_msvc

--- a/.github/workflows/windows_bazel_test.yml
+++ b/.github/workflows/windows_bazel_test.yml
@@ -1,0 +1,29 @@
+name: Windows Bazel Test
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Bazel Tests
+    runs-on: windows-latest
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bazel and Bazelisk
+        uses: bazel-contrib/setup-bazel@0.19.0 
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Run Tests
+        # msys2 'bash' on Windows will try to 'fix' the label prefix to
+        # work as a directory.
+        # //... won't work.
+        shell: bash
+        run: |
+          bazelisk test --config=msvc conformance:all

--- a/.github/workflows/windows_bazel_test_post_merge.yml
+++ b/.github/workflows/windows_bazel_test_post_merge.yml
@@ -1,0 +1,14 @@
+name: Windows Bazel Test (Post-Merge)
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  trigger-test:
+    # This prevents the workflow from running automatically when someone 
+    # pushes to their fork.
+    if: github.repository == 'google/cel-cpp'
+    
+    uses: ./.github/workflows/windows_bazel_test.yml

--- a/conformance/BUILD
+++ b/conformance/BUILD
@@ -115,6 +115,7 @@ cc_library(
         "@com_google_googleapis//google/rpc:code_cc_proto",
         "@com_google_protobuf//:protobuf",
         "@com_google_protobuf//src/google/protobuf/io",
+        "@rules_cc//cc/runfiles"
     ],
     alwayslink = True,
 )

--- a/conformance/run.bzl
+++ b/conformance/run.bzl
@@ -77,7 +77,7 @@ def _conformance_test_args(modern, optimize, recursive, select_opt, skip_check, 
 def _conformance_test(name, data, modern, optimize, recursive, select_opt, skip_check, skip_tests, tags, dashboard):
     cc_test(
         name = _conformance_test_name(name, optimize, recursive),
-        args = _conformance_test_args(modern, optimize, recursive, select_opt, skip_check, dashboard) + ["$(location " + test + ")" for test in data],
+        args = _conformance_test_args(modern, optimize, recursive, select_opt, skip_check, dashboard) + ["$(rlocationpath {})".format(test) for test in data],
         env = select(
             {
                 "@platforms//os:windows": {"CEL_SKIP_TESTS": ",".join(skip_tests + _TESTS_TO_SKIP_WINDOWS)},

--- a/conformance/run.cc
+++ b/conformance/run.cc
@@ -53,6 +53,7 @@
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/message.h"
 #include "google/protobuf/text_format.h"
+      #include "rules_cc/cc/runfiles/runfiles.h"
 
 ABSL_FLAG(bool, opt, false, "Enable optimizations (constant folding)");
 ABSL_FLAG(
@@ -69,7 +70,7 @@ ABSL_FLAG(bool, select_optimization, false, "Enable select optimization.");
 namespace {
 
 using ::testing::IsEmpty;
-
+using ::rules_cc::cc::runfiles::Runfiles;
 using cel::expr::conformance::test::SimpleTest;
 using cel::expr::conformance::test::SimpleTestFile;
 using google::api::expr::conformance::v1alpha1::CheckRequest;
@@ -271,6 +272,9 @@ NewConformanceServiceFromFlags() {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
+  std::string error;
+  auto runfiles = absl::WrapUnique(Runfiles::CreateForTest(BAZEL_CURRENT_REPOSITORY, &error));
+  ABSL_QCHECK(runfiles != nullptr) << absl::StrCat("failed to init runfiles", error);
   {
     auto service = NewConformanceServiceFromFlags();
     auto tests_to_skip = absl::GetFlag(FLAGS_skip_tests);
@@ -282,8 +286,9 @@ int main(int argc, char** argv) {
       }
     }
     for (int argi = 1; argi < argc; argi++) {
+      std::string path = runfiles->Rlocation(argv[argi]);
       ABSL_CHECK_OK(RegisterTestsFromFile(service, tests_to_skip,
-                                          absl::string_view(argv[argi])));
+                                          absl::string_view(path)));
     }
   }
   int exit_code = RUN_ALL_TESTS();


### PR DESCRIPTION
Add basic workflow for running conformance tests on windows.

Only run on post merge or manually for now.