### PR TITLE
fix code unit/code point mix-up in cord substring length

### DIFF
--- a/common/values/string_value.cc
+++ b/common/values/string_value.cc
@@ -742,7 +742,7 @@ absl::StatusOr<absl::Cord> SubstringImpl(const absl::Cord& cord, uint64_t start,
     }
     if (size_code_points == end) {
       return cord.Subcord(start_code_units,
-                          size_code_points - start_code_units);
+                          size_code_units - start_code_units);
     }
     char32_t code_point;
     size_t code_units;

--- a/common/values/string_value_test.cc
+++ b/common/values/string_value_test.cc
@@ -412,6 +412,35 @@ TEST_F(StringValueTest, CharAt) {
                   "<string>.charAt(<pos>): <pos> is less than 0")));
 }
 
+TEST_F(StringValueTest, Substring) {
+  using ::cel::test::ErrorValueIs;
+  using ::cel::test::StringValueIs;
+
+  // Each '€' is three bytes, so the cord built here is 18 bytes and is stored
+  // as a large (cord-backed) value. The substring length must be measured in
+  // code units, not code points, otherwise the cord overload truncates a
+  // multi-byte character or underflows the length.
+  StringValue unicode_cord = StringValue(absl::Cord("€€€€€€"));
+  StringValue unicode_view = StringValue("€€€€€€");
+
+  EXPECT_THAT(unicode_cord.Substring(0, 2), StringValueIs("€€"));
+  EXPECT_THAT(unicode_view.Substring(0, 2), StringValueIs("€€"));
+  EXPECT_THAT(unicode_cord.Substring(1, 2), StringValueIs("€"));
+  EXPECT_THAT(unicode_view.Substring(1, 2), StringValueIs("€"));
+  EXPECT_THAT(unicode_cord.Substring(2, 4), StringValueIs("€€"));
+  EXPECT_THAT(unicode_view.Substring(2, 4), StringValueIs("€€"));
+  EXPECT_THAT(unicode_cord.Substring(2), StringValueIs("€€€€"));
+  EXPECT_THAT(unicode_view.Substring(2), StringValueIs("€€€€"));
+
+  EXPECT_THAT(unicode_cord.Substring(0, 7),
+              ErrorValueIs(absl::InvalidArgumentError(
+                  "<string>.substring(<start>, <end>): <start> or <end> is "
+                  "greater than <string>.size()")));
+  EXPECT_THAT(unicode_cord.Substring(-1),
+              ErrorValueIs(absl::InvalidArgumentError(
+                  "<string>.substring(<start>): <start> is less than 0")));
+}
+
 TEST_F(StringValueTest, Join) {
   using ::cel::runtime_internal::CreateNoMatchingOverloadError;
   using ::cel::test::ErrorValueIs;


### PR DESCRIPTION
The cord overload of `SubstringImpl` in common/values/string_value.cc:745 passes `size_code_points - start_code_units` as the byte length to `Subcord`, mixing a code-point count with a byte offset. Use `size_code_units` so large strings backed by a cord return the correct bytes instead of a truncated or over-long range on multi-byte input.