### PR TITLE
fix undefined left shift of negative int in math.bitShiftLeft

### DIFF
--- a/extensions/math_ext.cc
+++ b/extensions/math_ext.cc
@@ -266,7 +266,11 @@ Value BitShiftLeftInt(int64_t lhs, int64_t rhs) {
   if (rhs > 63) {
     return IntValue(0);
   }
-  return IntValue(lhs << static_cast<int>(rhs));
+  // Shift in the unsigned domain to avoid undefined behaviour when lhs is
+  // negative or the shift moves bits into the sign bit, matching the bit
+  // pattern semantics already used by bitShiftRight.
+  return IntValue(absl::bit_cast<int64_t>(absl::bit_cast<uint64_t>(lhs)
+                                          << static_cast<int>(rhs)));
 }
 
 Value BitShiftLeftUint(uint64_t lhs, int64_t rhs) {

--- a/extensions/math_ext_test.cc
+++ b/extensions/math_ext_test.cc
@@ -563,6 +563,8 @@ INSTANTIATE_TEST_SUITE_P(
          {"math.bitNot(2) == -3"},
          {"math.bitAnd(math.bitNot(0x3u), 0xFFu) == 0xFCu"},
          {"math.bitShiftLeft(1, 1) == 2"},
+         {"math.bitShiftLeft(-1, 1) == -2"},
+         {"math.bitShiftLeft(-4, 2) == -16"},
          {"math.bitShiftLeft(1u, 1) == 2u"},
          {"math.bitShiftRight(4, 1) == 2"},
          {"math.bitShiftRight(4u, 1) == 2u"}}));


### PR DESCRIPTION
Noticed bitShiftLeft shifts a signed int64 directly while bitShiftRight goes through an unsigned bit_cast first. For a negative left operand like math.bitShiftLeft(-1, 1) that signed left shift is undefined behaviour, which ubsan flags as left shift of negative value. Shifting in the unsigned domain the way the right shift already does keeps the same bit pattern result without the UB. Added a couple of negative-operand cases to the runtime tests since they weren't covered before.